### PR TITLE
dm-zoned metadata handling and device-mapper integration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,10 +31,15 @@ AC_CHECK_HEADER(blkid/blkid.h, [],
 		[AC_MSG_ERROR([Couldn't find blkid/blkid.h])])
 AC_CHECK_HEADER(linux/blkzoned.h, [],
 		[AC_MSG_ERROR([Couldn't find linux/blkzoned.h])])
+AC_CHECK_HEADER(libdevmapper.h, [],
+		[AC_MSG_ERROR([Couldn't find libdevmapper.h])])
 
 # Checks for libraries.
 AC_SEARCH_LIBS([blkid_do_fullprobe], [blkid], [],
 	       [AC_MSG_ERROR([Couldn't find libblkid])])
+
+AC_SEARCH_LIBS([dm_task_run], [devmapper], [],
+		[AC_MSG_ERROR([Couldn't find libdevmapper])])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -31,12 +31,17 @@ AC_CHECK_HEADER(blkid/blkid.h, [],
 		[AC_MSG_ERROR([Couldn't find blkid/blkid.h])])
 AC_CHECK_HEADER(linux/blkzoned.h, [],
 		[AC_MSG_ERROR([Couldn't find linux/blkzoned.h])])
+AC_CHECK_HEADER(uuid/uuid.h, [],
+		[AC_MSG_ERROR([Couldn't find uuid/uuid.h])])
 AC_CHECK_HEADER(libdevmapper.h, [],
 		[AC_MSG_ERROR([Couldn't find libdevmapper.h])])
 
 # Checks for libraries.
 AC_SEARCH_LIBS([blkid_do_fullprobe], [blkid], [],
 	       [AC_MSG_ERROR([Couldn't find libblkid])])
+
+AC_SEARCH_LIBS([uuid_generate_random], [uuid], [],
+		[AC_MSG_ERROR([Couldn't find libuuid])])
 
 AC_SEARCH_LIBS([dm_task_run], [devmapper], [],
 		[AC_MSG_ERROR([Couldn't find libdevmapper])])

--- a/man/dmzadm.8
+++ b/man/dmzadm.8
@@ -53,6 +53,10 @@ Check the zoned block device metadata consistency and try to repair any error
 detected.
 
 .TP
+.B Start
+Load the metadata information from disk and activate the device-mapper target.
+
+.TP
 .B Help
 Print a short usage description of dmzadm
 
@@ -72,6 +76,10 @@ Check a zoned block device metadata.
 .TP
 .BR \-\-repair
 Check a zoned block device metadata and attempt to repair any error found.
+
+.TP
+.BR \-\-start
+Load zoned block device metadata and activate the device-mapper target.
 
 .TP
 .BR \-\-help ", " \-h
@@ -94,6 +102,12 @@ Very detailed output of actions taken.
 .TP
 .BR \-\-seq=<num>
 Specify the number of sequential zones to be reserved for reclaim.
+
+.TP
+.BR \-\-label=<str>
+Sets the name for the device-mapper device. Defaults to
+.I dmz-<devname>
+.
 
 .TP
 .SH AUTHOR

--- a/man/dmzadm.8
+++ b/man/dmzadm.8
@@ -57,6 +57,10 @@ detected.
 Load the metadata information from disk and activate the device-mapper target.
 
 .TP
+.B Stop
+Deactivate the device-mapper target associated with the zoned block device.
+
+.TP
 .B Help
 Print a short usage description of dmzadm
 
@@ -80,6 +84,10 @@ Check a zoned block device metadata and attempt to repair any error found.
 .TP
 .BR \-\-start
 Load zoned block device metadata and activate the device-mapper target.
+
+.TP
+.BR \-\-start
+Deactivate the device-mapper target for a zoned block device.
 
 .TP
 .BR \-\-help ", " \-h

--- a/man/dmzadm.8
+++ b/man/dmzadm.8
@@ -92,7 +92,7 @@ Very detailed output of actions taken.
 \fIFormat\fP operation options:
 
 .TP
-.BR \-\-seq <num>
+.BR \-\-seq=<num>
 Specify the number of sequential zones to be reserved for reclaim.
 
 .TP

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,6 +7,7 @@ CFILES = dmz_dev.c \
 	 dmz_lib.c \
 	 dmz_format.c \
 	 dmz_check.c \
+	 dmz_devmapper.c \
 	 dmzadm.c
 HFILES = dmz.h
 

--- a/src/dmz.h
+++ b/src/dmz.h
@@ -25,13 +25,15 @@
 #include <limits.h>
 #include <sys/types.h>
 #include <linux/blkzoned.h>
+#include <uuid/uuid.h>
 
 /***** Type definitions *****/
 
 /*
  * Metadata version.
  */
-#define DMZ_META_VER	1
+#define DMZ_META_COMPAT_VER	1
+#define DMZ_META_VER	2
 
 /*
  * On-disk super block magic.
@@ -85,8 +87,18 @@ struct dm_zoned_super {
 	/* Checksum */
 	__le32		crc;			/*  48 */
 
+	/* Fields added by Metadata version 2 */
+	/* DM-Zoned label */
+	__u8		dmz_label[32];		/*  80 */
+
+	/* DM-Zoned UUID */
+	__u8		dmz_uuid[16];		/*  96 */
+
+	/* Device UUID */
+	__u8		dev_uuid[16];		/*  112 */
+
 	/* Padding to full 512B sector */
-	__u8		reserved[464];		/* 512 */
+	__u8		reserved[400];		/* 512 */
 
 } __attribute__ ((packed));
 
@@ -166,6 +178,8 @@ struct dmz_dev {
 	int		op;
 	unsigned int	flags;
 	char		dmz_label[16];
+	uuid_t		dmz_uuid;
+	uuid_t		dev_uuid;
 
 	/* Device info */
 	__u64		capacity;

--- a/src/dmz.h
+++ b/src/dmz.h
@@ -147,14 +147,21 @@ struct dm_zoned_map {
 #define DMZ_NR_RESERVED_SEQ	16
 
 /*
+ * Device types.
+ */
+enum dmz_dev_type {
+	DMZ_TYPE_ZONED_HA = 1,
+	DMZ_TYPE_ZONED_HM,
+	DMZ_TYPE_REGULAR,
+};
+
+/*
  * Device flags.
  */
 #define DMZ_VERBOSE		0x00000001
 #define DMZ_VVERBOSE		0x00000002
 #define DMZ_REPAIR		0x00000004
-#define DMZ_ZONED_HA		0x00000010
-#define DMZ_ZONED_HM		0x00000020
-#define DMZ_OVERWRITE		0x00000040
+#define DMZ_OVERWRITE		0x00000008
 
 /*
  * Operations.
@@ -175,10 +182,7 @@ struct dmz_dev {
 	/* Device file path and basename */
 	char		*path;
 	char		*name;
-	int		op;
-	unsigned int	flags;
-	char		dmz_label[16];
-	uuid_t		dmz_uuid;
+	enum dmz_dev_type dev_type;
 	uuid_t		dev_uuid;
 
 	/* Device info */
@@ -194,6 +198,7 @@ struct dmz_dev {
 	unsigned int	last_meta_zone;
 	unsigned int	total_nr_meta_zones;
 	unsigned int	nr_rnd_zones;
+	unsigned int	nr_cache_zones;
 
 	struct blk_zone	*zones;
 
@@ -244,6 +249,27 @@ struct dmz_meta_set {
 
 };
 
+/*,
+ * DM-zoned device set
+ */
+struct dmz_dev_set {
+	int		op;
+	unsigned int	flags;
+	unsigned int	if_version;
+
+	char		dmz_label[16];
+	uuid_t		dmz_uuid;
+
+	/* Device info */
+	__u64		capacity;
+	unsigned int	nr_zones;
+
+	size_t		zone_nr_sectors;
+	size_t		zone_nr_blocks;
+
+	struct dmz_dev	dev[1];
+};
+
 /*
  * Bitmap operations.
  */
@@ -273,8 +299,8 @@ static inline void dmz_clear_bit(__u8 *bitmap,
 				 DMZ_MSET_MAP_VALID |	\
 				 DMZ_MSET_BITMAP_VALID)
 
-#define dmz_dev_is_ha(dev)	((dev)->flags & DMZ_ZONED_HA)
-#define dmz_dev_is_hm(dev)	((dev)->flags & DMZ_ZONED_HM)
+#define dmz_dev_is_ha(dev)	((dev)->dev_type == DMZ_TYPE_ZONED_HA)
+#define dmz_dev_is_hm(dev)	((dev)->dev_type == DMZ_TYPE_ZONED_HM)
 #define dmz_dev_is_zoned(dev)	(dmz_dev_is_ha(dev) || dmz_dev_is_hm(dev))
 
 #define dmz_zone_type(z)	(z)->type
@@ -333,7 +359,7 @@ dmz_zone_cond_str(struct blk_zone *zone)
 #define dmz_zone_need_reset(z)	(int)(z)->reset
 #define dmz_zone_non_seq(z)	(int)(z)->non_seq
 
-extern int dmz_open_dev(struct dmz_dev *dev, enum dmz_op op);
+extern int dmz_open_dev(struct dmz_dev *dev, enum dmz_op op, int flags);
 extern void dmz_close_dev(struct dmz_dev *dev);
 extern int dmz_get_dev_holder(struct dmz_dev *dev, char *holder);
 extern int dmz_sync_dev(struct dmz_dev *dev);
@@ -344,13 +370,14 @@ extern int dmz_read_block(struct dmz_dev *dev, __u64 block, __u8 *buf);
 
 extern __u32 dmz_crc32(__u32 crc, const void *address, size_t length);
 
-extern int dmz_locate_metadata(struct dmz_dev *dev);
-extern int dmz_write_super(struct dmz_dev *dev, __u64 gen, __u64 offset);
-extern int dmz_format(struct dmz_dev *dev);
-extern int dmz_check(struct dmz_dev *dev);
-extern int dmz_repair(struct dmz_dev *dev);
+extern int dmz_locate_metadata(struct dmz_dev_set *set, int idx);
+extern int dmz_write_super(struct dmz_dev_set *set, int idx,
+			   __u64 gen, __u64 offset);
+extern int dmz_format(struct dmz_dev_set *set);
+extern int dmz_check(struct dmz_dev_set *set);
+extern int dmz_repair(struct dmz_dev_set *set);
 extern int dmz_init_dm(int log_level);
-extern int dmz_start(struct dmz_dev *dev);
-extern int dmz_stop(struct dmz_dev *dev, char *dm_dev);
+extern int dmz_start(struct dmz_dev_set *set);
+extern int dmz_stop(struct dmz_dev_set *set, char *dm_dev);
 
 #endif /* __DMZ_H__ */

--- a/src/dmz.h
+++ b/src/dmz.h
@@ -151,7 +151,7 @@ struct dm_zoned_map {
  */
 #define DMZ_VERBOSE		0x00000001
 #define DMZ_VVERBOSE		0x00000002
-#define DMZ_REPAIR  		0x00000004
+#define DMZ_REPAIR		0x00000004
 #define DMZ_ZONED_HA		0x00000010
 #define DMZ_ZONED_HM		0x00000020
 #define DMZ_OVERWRITE		0x00000040
@@ -227,17 +227,17 @@ struct dmz_meta_set {
 	int		id;
 	unsigned int	flags;
 
-	__u64 		sb_block;
+	__u64		sb_block;
 	__u64		map_block;
 	__u64		bitmap_block;
 
-	__u8 		buf[DMZ_BLOCK_SIZE];
-	__u8 		*map_buf;
+	__u8		buf[DMZ_BLOCK_SIZE];
+	__u8		*map_buf;
 
-	__u64 		gen;
+	__u64		gen;
 
-	unsigned int 	nr_mapped_chunks;
-	unsigned int 	nr_buf_chunks;
+	unsigned int	nr_mapped_chunks;
+	unsigned int	nr_buf_chunks;
 
 	unsigned int	error_count;
 	unsigned int	total_error_count;
@@ -277,7 +277,7 @@ static inline void dmz_clear_bit(__u8 *bitmap,
 #define dmz_dev_is_hm(dev)	((dev)->flags & DMZ_ZONED_HM)
 #define dmz_dev_is_zoned(dev)	(dmz_dev_is_ha(dev) || dmz_dev_is_hm(dev))
 
-#define dmz_zone_type(z)        (z)->type
+#define dmz_zone_type(z)	(z)->type
 #define dmz_zone_conv(z)	((z)->type == BLK_ZONE_TYPE_CONVENTIONAL)
 #define dmz_zone_seq_req(z)	((z)->type == BLK_ZONE_TYPE_SEQWRITE_REQ)
 #define dmz_zone_seq_pref(z)	((z)->type == BLK_ZONE_TYPE_SEQWRITE_PREF)

--- a/src/dmz.h
+++ b/src/dmz.h
@@ -186,6 +186,7 @@ struct dmz_dev {
 	size_t		zone_nr_blocks;
 
 	/* First metadata zone */
+	unsigned int	sb_version;
 	struct blk_zone	*sb_zone;
 	__u64		sb_block;
 
@@ -332,6 +333,7 @@ extern int dmz_write_super(struct dmz_dev *dev, __u64 gen, __u64 offset);
 extern int dmz_format(struct dmz_dev *dev);
 extern int dmz_check(struct dmz_dev *dev);
 extern int dmz_repair(struct dmz_dev *dev);
+extern int dmz_init_dm(int log_level);
 extern int dmz_start(struct dmz_dev *dev);
 
 #endif /* __DMZ_H__ */

--- a/src/dmz.h
+++ b/src/dmz.h
@@ -152,6 +152,7 @@ enum dmz_op {
 	DMZ_OP_CHECK,
 	DMZ_OP_REPAIR,
 	DMZ_OP_START,
+	DMZ_OP_STOP,
 };
 
 /*
@@ -320,6 +321,7 @@ dmz_zone_cond_str(struct blk_zone *zone)
 
 extern int dmz_open_dev(struct dmz_dev *dev, enum dmz_op op);
 extern void dmz_close_dev(struct dmz_dev *dev);
+extern int dmz_get_dev_holder(struct dmz_dev *dev, char *holder);
 extern int dmz_sync_dev(struct dmz_dev *dev);
 extern int dmz_reset_zone(struct dmz_dev *dev, struct blk_zone *zone);
 extern int dmz_reset_zones(struct dmz_dev *dev);
@@ -335,5 +337,6 @@ extern int dmz_check(struct dmz_dev *dev);
 extern int dmz_repair(struct dmz_dev *dev);
 extern int dmz_init_dm(int log_level);
 extern int dmz_start(struct dmz_dev *dev);
+extern int dmz_stop(struct dmz_dev *dev, char *dm_dev);
 
 #endif /* __DMZ_H__ */

--- a/src/dmz.h
+++ b/src/dmz.h
@@ -151,6 +151,7 @@ enum dmz_op {
 	DMZ_OP_FORMAT = 1,
 	DMZ_OP_CHECK,
 	DMZ_OP_REPAIR,
+	DMZ_OP_START,
 };
 
 /*
@@ -163,6 +164,7 @@ struct dmz_dev {
 	char		*name;
 	int		op;
 	unsigned int	flags;
+	char		dmz_label[16];
 
 	/* Device info */
 	__u64		capacity;
@@ -330,5 +332,6 @@ extern int dmz_write_super(struct dmz_dev *dev, __u64 gen, __u64 offset);
 extern int dmz_format(struct dmz_dev *dev);
 extern int dmz_check(struct dmz_dev *dev);
 extern int dmz_repair(struct dmz_dev *dev);
+extern int dmz_start(struct dmz_dev *dev);
 
 #endif /* __DMZ_H__ */

--- a/src/dmz_check.c
+++ b/src/dmz_check.c
@@ -518,7 +518,11 @@ static int dmz_check_mapped_zone_bitmap(struct dmz_dev *dev,
 
 	/* No valid block should be present after the write pointer */
 	bad_bits = 0;
-	wp_block = dmz_sect2blk(zone->wp - zone->start);
+	/* Check for full zones */
+	if (zone->wp == (__u64)-1)
+		wp_block = dev->zone_nr_blocks;
+	else
+		wp_block = dmz_sect2blk(zone->wp - zone->start);
 	for (b = 0; b < wp_block; b++) {
 		if (dmz_test_bit(dbuf, b))
 			dzone_weight++;

--- a/src/dmz_devmapper.c
+++ b/src/dmz_devmapper.c
@@ -34,6 +34,13 @@ int dmz_create_dm(struct dmz_dev_set *set, int idx)
 	__u64 capacity = dev->nr_zones * dev->zone_nr_sectors;
 	__u16 udev_flags = DM_UDEV_DISABLE_LIBRARY_FALLBACK;
 
+	/*
+	 * dm-zoned interface version 3 allows for capacity
+	 * being different than the resulting device size.
+	 */
+	if (set->if_version > 2)
+		capacity = dev->nr_chunks * dev->zone_nr_sectors;
+
 	if (!(dmt = dm_task_create (DM_DEVICE_CREATE)))
 		return -ENOMEM;
 

--- a/src/dmz_devmapper.c
+++ b/src/dmz_devmapper.c
@@ -1,0 +1,167 @@
+/*
+ * This file is part of dm-zoned tools.
+ *
+ * Copyright (C) 2020, SUSE Linux. All rights reserved.
+ *
+ * This software is distributed under the terms of the BSD 2-clause license,
+ * "as is," without technical support, and WITHOUT ANY WARRANTY, without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. You should have received a copy of the BSD 2-clause license along
+ * with dm-zoned tools.
+ * If not, see <http://opensource.org/licenses/BSD-2-Clause>.
+ *
+ * Authors: Hannes Reinecke (hare@suse.com)
+ */
+
+#include "dmz.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+#include <asm/byteorder.h>
+
+#include <libdevmapper.h>
+
+int dmz_create_dm(struct dmz_dev *dev)
+{
+	int ret = -EINVAL;
+	struct dm_task *dmt;
+	uint32_t cookie = 0;
+	int log_level = 0;
+	__u64 capacity = dev->nr_zones * dev->zone_nr_sectors;
+	__u16 udev_flags = DM_UDEV_DISABLE_LIBRARY_FALLBACK;
+
+	dm_log_with_errno_init(NULL);
+
+	if (dev->flags & DMZ_VVERBOSE)
+		log_level++;
+	dm_log_init_verbose(log_level);
+
+	if (!(dmt = dm_task_create (DM_DEVICE_CREATE)))
+		return -ENOMEM;
+
+	if (!dm_task_set_name (dmt, dev->dmz_label))
+		goto out;
+
+	if (!dm_task_add_target (dmt, 0, capacity, "zoned", dev->path))
+		goto out;
+
+	dm_task_skip_lockfs(dmt);
+	dm_task_no_flush(dmt);
+	dm_task_no_open_count(dmt);
+
+	if (dm_task_set_cookie(dmt, &cookie, udev_flags)) {
+		if (dm_task_run (dmt)) {
+			dm_udev_wait(cookie);
+			ret = 0;
+		}
+	}
+
+out:
+	dm_task_destroy(dmt);
+
+	return ret;
+}
+
+/*
+ * Load the contents of a super block
+ */
+static int dmz_load_sb(struct dmz_dev *dev)
+{
+	struct dm_zoned_super *sb;
+	unsigned char *buf;
+	__u32 stored_crc, calculated_crc;
+	int ret;
+
+	buf = malloc(DMZ_BLOCK_SIZE);
+	if (!buf)
+		return -ENOMEM;
+
+	sb = (struct dm_zoned_super *)buf;
+	ret = dmz_read_block(dev, dev->sb_block, buf);
+	if (ret != 0) {
+		ret = -EIO;
+		goto out;
+	}
+
+	/* Check magic */
+	if (__le32_to_cpu(sb->magic) != DMZ_MAGIC) {
+		fprintf(stderr,
+			"%s: invalid magic (expected 0x%08x read 0x%08x)\n",
+			dev->name, DMZ_MAGIC, __le32_to_cpu(sb->magic));
+		ret = -EINVAL;
+		goto out;
+	}
+
+	/* Check CRC */
+	stored_crc = __le32_to_cpu(sb->crc);
+	sb->crc = 0;
+	calculated_crc = dmz_crc32(sb->gen, buf, DMZ_BLOCK_SIZE);
+	if (calculated_crc != stored_crc) {
+		fprintf(stderr,
+			"%s: invalid crc (expected 0x%08x, read 0x%08x)\n",
+			dev->name, calculated_crc, stored_crc);
+		ret = -EINVAL;
+		goto out;
+	}
+
+	/* Check version */
+	if (__le32_to_cpu(sb->version) > DMZ_META_VER) {
+		fprintf(stderr,
+			"%s: invalid version (expected 0x%x, read 0x%x)\n",
+			dev->name, DMZ_META_VER, __le32_to_cpu(sb->version));
+		ret = -EINVAL;
+		goto out;
+	}
+
+	/* OK */
+	if (dev->flags & DMZ_VERBOSE)
+		printf("%s: loaded superblock (version %d, generation %llu)\n",
+		       dev->name, __le32_to_cpu(sb->version),
+		       __le64_to_cpu(sb->gen));
+
+out:
+	free(sb);
+	return ret;
+}
+
+int dmz_start(struct dmz_dev *dev)
+{
+	/* Calculate metadata location */
+	if (dev->flags & DMZ_VERBOSE)
+		printf("%s: Locating metadata...\n", dev->name);
+	if (dmz_locate_metadata(dev) < 0) {
+		fprintf(stderr,
+			"%s: Failed to locate metadata\n", dev->name);
+		return -1;
+	}
+
+	/* Check primary super block */
+	if (dev->flags & DMZ_VERBOSE)
+		printf("%s: Primary metadata set at block %llu (zone %u)\n",
+		       dev->name, dev->sb_block,
+		       dmz_zone_id(dev, dev->sb_zone));
+
+	if (dmz_load_sb(dev) < 0) {
+		fprintf(stderr,
+			"%s: Failed to load metadata\n", dev->name);
+		return -1;
+	}
+
+	/* Generate dm name if not set */
+	if (!strlen(dev->dmz_label))
+		sprintf(dev->dmz_label, "dmz-%s", dev->name);
+
+	printf("%s: starting %s\n",
+	       dev->name, dev->dmz_label);
+
+	if (dmz_create_dm(dev)) {
+		fprintf(stderr,
+			"%s: Failed to start %s", dev->name, dev->dmz_label);
+		return -1;
+	}
+	return 0;
+}

--- a/src/dmz_lib.c
+++ b/src/dmz_lib.c
@@ -88,8 +88,9 @@ int dmz_reset_zones(struct dmz_dev *dev)
 /*
  * Determine location and amount of metadata blocks.
  */
-int dmz_locate_metadata(struct dmz_dev *dev)
+int dmz_locate_metadata(struct dmz_dev_set *set, int idx)
 {
+	struct dmz_dev *dev = &set->dev[idx];
 	struct blk_zone *zone;
 	unsigned int i = 0;
 	unsigned int nr_meta_blocks, nr_map_blocks;

--- a/src/dmzadm.c
+++ b/src/dmzadm.c
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
 {
 	unsigned int nr_zones;
 	struct dmz_dev dev;
-	int i, ret;
+	int i, ret, log_level = 0;
 	enum dmz_op op;
 
 	/* Initialize */
@@ -102,10 +102,12 @@ int main(int argc, char **argv)
 		if (strcmp(argv[i], "--verbose") == 0) {
 
 			dev.flags |= DMZ_VERBOSE;
+			log_level = 1;
 
 		} else if (strcmp(argv[i], "--vverbose") == 0) {
 
 			dev.flags |= DMZ_VERBOSE | DMZ_VVERBOSE;
+			log_level = 2;
 
 		} else if (strncmp(argv[i], "--seq=", 6) == 0) {
 
@@ -148,6 +150,14 @@ int main(int argc, char **argv)
 		}
 
 	}
+
+	/* Check device-mapper target version */
+	ret = dmz_init_dm(log_level);
+	if (ret <= 0)
+		return 1;
+
+	dev.sb_version = ret;
+	printf("Using interface version %d\n", dev.sb_version);
 
 	/* Open the device */
 	if (dmz_open_dev(&dev, op) < 0)

--- a/src/dmzadm.c
+++ b/src/dmzadm.c
@@ -39,7 +39,7 @@ static void dmzadm_usage(void)
 
 	printf("Format operation options\n"
 	       "  --force	: Force overwrite of existing content\n"
-	       "  --seq <num>	: Number of sequential zones reserved\n"
+	       "  --seq=<num>	: Number of sequential zones reserved\n"
 	       "                  for reclaim. The minimum is 1 and the\n"
 	       "                  default is %d\n",
 	       DMZ_NR_RESERVED_SEQ);

--- a/src/dmzadm.c
+++ b/src/dmzadm.c
@@ -128,6 +128,27 @@ int main(int argc, char **argv)
 				return 1;
 			}
 
+		} else if (strncmp(argv[i], "--label=", 8) == 0) {
+			const char *label = argv[i] + 8;
+			unsigned int label_size = strlen(label);
+
+			if (op != DMZ_OP_FORMAT) {
+				fprintf(stderr,
+					"--label option is valid only with the "
+					"format operation\n");
+				return 1;
+			}
+			if (label[0] == '\'' || label[0] == '\"') {
+				label++;
+				label_size -= 2;
+			}
+			if (label_size > 31) {
+				fprintf(stderr,
+					"Label too long (max 16 characters)\n");
+				return 1;
+			}
+			memcpy(dev.dmz_label, label, label_size);
+
 		} else if (strcmp(argv[i], "--force") == 0) {
 
 			if (op != DMZ_OP_FORMAT) {

--- a/src/dmzadm.c
+++ b/src/dmzadm.c
@@ -31,7 +31,8 @@ static void dmzadm_usage(void)
 	       "  --help | -h	: General help message\n"
 	       "  --format	: Format a block device metadata\n"
 	       "  --check	: Check a block device metadata\n"
-	       "  --repair	: Repair a block device metadata\n");
+	       "  --repair	: Repair a block device metadata\n"
+	       "  --start	: Start the device-mapper target\n");
 
 	printf("General options\n"
 	       "  --verbose	: Verbose output\n"
@@ -39,6 +40,7 @@ static void dmzadm_usage(void)
 
 	printf("Format operation options\n"
 	       "  --force	: Force overwrite of existing content\n"
+	       "  --label=<str> : Set the name to <str>\n"
 	       "  --seq=<num>	: Number of sequential zones reserved\n"
 	       "                  for reclaim. The minimum is 1 and the\n"
 	       "                  default is %d\n",
@@ -77,6 +79,8 @@ int main(int argc, char **argv)
 		op = DMZ_OP_CHECK;
 	} else if (strcmp(argv[1], "--repair") == 0) {
 		op = DMZ_OP_REPAIR;
+	} else if (strcmp(argv[1], "--start") == 0) {
+		op = DMZ_OP_START;
 	} else {
 		fprintf(stderr,
 			"Unknown operation \"%s\"\n",
@@ -182,6 +186,10 @@ int main(int argc, char **argv)
 
 	case DMZ_OP_REPAIR:
 		ret = dmz_repair(&dev);
+		break;
+
+	case DMZ_OP_START:
+		ret = dmz_start(&dev);
 		break;
 
 	default:

--- a/src/dmzadm.c
+++ b/src/dmzadm.c
@@ -32,7 +32,8 @@ static void dmzadm_usage(void)
 	       "  --format	: Format a block device metadata\n"
 	       "  --check	: Check a block device metadata\n"
 	       "  --repair	: Repair a block device metadata\n"
-	       "  --start	: Start the device-mapper target\n");
+	       "  --start	: Start the device-mapper target\n"
+	       "  --stop	: Stop the device-mapper target\n");
 
 	printf("General options\n"
 	       "  --verbose	: Verbose output\n"
@@ -81,6 +82,8 @@ int main(int argc, char **argv)
 		op = DMZ_OP_REPAIR;
 	} else if (strcmp(argv[1], "--start") == 0) {
 		op = DMZ_OP_START;
+	} else if (strcmp(argv[1], "--stop") == 0) {
+		op = DMZ_OP_STOP;
 	} else {
 		fprintf(stderr,
 			"Unknown operation \"%s\"\n",
@@ -158,6 +161,19 @@ int main(int argc, char **argv)
 
 	dev.sb_version = ret;
 	printf("Using interface version %d\n", dev.sb_version);
+
+	if (op == DMZ_OP_STOP) {
+		char holder[PATH_MAX];
+
+		if (dmz_get_dev_holder(&dev, holder) < 0)
+			return 1;
+		if (!strlen(holder)) {
+			fprintf(stderr, "%s: no dm-zoned device found\n",
+				dev.name);
+			return 1;
+		}
+		return dmz_stop(&dev, holder);
+	}
 
 	/* Open the device */
 	if (dmz_open_dev(&dev, op) < 0)


### PR DESCRIPTION
Hi Damien,

as threatened here's a patchset which provides a 'proper' device-mapper integration (so that we now have a --start and --stop option) and updates the on-disk metadata to V2 which includes UUIDs and labels.
Kernel patches to be posted soon.