### PR TITLE
dmzadm: reshuffle devices

### DIFF
--- a/man/dmzadm.8
+++ b/man/dmzadm.8
@@ -12,7 +12,7 @@ mapper
 .I operation
 >
 <
-.I zoned-block-device
+.I [regular-block-device] zoned-block-device
 >
 [
 .I options
@@ -22,9 +22,11 @@ mapper
 .B dmzadm
 is used to format, check and repair a zoned block device used with the dm-zoned
 device mapper. 
-\fIzoned-block-device\fP is the special file corresponding to the target zoned
+\fIzoned-block-device\fP is the device node corresponding to the target zoned
 blocks device (e.g.
 \fI/dev/sdXX\fP).
+\fIregular-block-device\fP is the optional device node corresponding to a
+regular block device to be used together with the zoned block devoce.
 \fIoperation\fP specifies the action to be taken for the device.
 .PP
 The exit code returned by
@@ -37,28 +39,29 @@ dmzadm allows the following operations.
 
 .TP
 .B Format
-Write to the zoned block device dm-zoned metadata, whiping clean all data that
-was stored on the device.
+Write to the zoned block device and optional regular block device dm-zoned
+metadata, whiping clean all data that was stored on the device.
 
 .TP
 .B Check
-Check the zoned block device metadata consistency. No repair action is taken.
+Check the device(s) metadata consistency. No repair action is taken.
 Errors are not corrected with this operation. For repairing incorrect metadata,
 the
 \fIRepair\fP operation must be used.
 
 .TP
 .B Repair
-Check the zoned block device metadata consistency and try to repair any error
+Check the device metadata consistency and try to repair any error
 detected.
 
 .TP
 .B Start
-Load the metadata information from disk and activate the device-mapper target.
+Load the metadata information from disk(s) and activate the device-mapper
+target.
 
 .TP
 .B Stop
-Deactivate the device-mapper target associated with the zoned block device.
+Deactivate the device-mapper target associated with the block device(s).
 
 .TP
 .B Help
@@ -71,22 +74,22 @@ Options for selecting an operation are:
 
 .TP
 .BR \-\-format
-Format a zoned block device.
+Format the specified block device(s).
 
 .TP
 .BR \-\-check
-Check a zoned block device metadata.
+Check the specified block device(s) metadata.
 
 .TP
 .BR \-\-repair
-Check a zoned block device metadata and attempt to repair any error found.
+Check the block device(s) metadata and attempt to repair any error found.
 
 .TP
 .BR \-\-start
-Load zoned block device metadata and activate the device-mapper target.
+Load block device(s) metadata and activate the device-mapper target.
 
 .TP
-.BR \-\-start
+.BR \-\-stop
 Deactivate the device-mapper target for a zoned block device.
 
 .TP

--- a/src/dmz_dev.c
+++ b/src/dmz_dev.c
@@ -44,11 +44,11 @@ dmz_block_to_bdev(struct dmz_dev *dev, __u64 block, __u64 *ret_block)
 	if (!dev->bdev[1].name)
 		return &dev->bdev[0];
 
-	if (block < dev->bdev[0].block_offset)
-		return &dev->bdev[1];
+	if (block < dev->bdev[1].block_offset)
+		return &dev->bdev[0];
 
-	*ret_block -= dev->bdev[0].block_offset;
-	return &dev->bdev[0];
+	*ret_block -= dev->bdev[1].block_offset;
+	return &dev->bdev[1];
 }
 
 unsigned int dmz_block_zone_id(struct dmz_dev *dev, __u64 block)
@@ -297,17 +297,17 @@ int dmz_get_dev_zones(struct dmz_dev *dev)
 
 	sector = 0;
 	while (sector < dev->capacity) {
-		__u64 sector_offset = dmz_blk2sect(dev->bdev[0].block_offset);
+		__u64 sector_offset = dmz_blk2sect(dev->bdev[1].block_offset);
 		__u64 bdev_sector;
 
 		if (!dev->bdev[1].name) {
 			bdev = &dev->bdev[0];
 			bdev_sector = sector;
 		} else if (sector < sector_offset) {
-			bdev = &dev->bdev[1];
+			bdev = &dev->bdev[0];
 			bdev_sector = sector;
 		} else {
-			bdev = &dev->bdev[0];
+			bdev = &dev->bdev[1];
 			bdev_sector = sector - sector_offset;
 		}
 		if (bdev->type == DMZ_TYPE_REGULAR) {

--- a/src/dmz_devmapper.c
+++ b/src/dmz_devmapper.c
@@ -55,7 +55,7 @@ int dmz_init_dm(int log_level)
 				       tgt->version[0], tgt->version[1],
 				       tgt->version[2]);
 			ret = 0;
-			if (tgt->version[0] == 1 || tgt->version[0] == 2) {
+			if (tgt->version[0] <= DMZ_META_VER) {
 				ret = tgt->version[0];
 				break;
 			}
@@ -88,18 +88,18 @@ int dmz_create_dm(struct dmz_dev *dev)
 	 */
 	capacity = dev->nr_chunks * dev->zone_nr_sectors;
 
-	if (!(dmt = dm_task_create(DM_DEVICE_CREATE)))
+	if (!(dmt = dm_task_create (DM_DEVICE_CREATE)))
 		return -ENOMEM;
 
-	if (!dm_task_set_name(dmt, dev->label))
+	if (!dm_task_set_name (dmt, dev->label))
 		goto out;
 
 	if (dev->sb_version > 1 && dev->bdev[1].path)
-		sprintf(params, "%s %s", dev->bdev[1].path, dev->bdev[0].path);
+		sprintf(params, "%s %s", dev->bdev[0].path, dev->bdev[1].path);
 	else
 		sprintf(params, "%s", dev->bdev[0].path);
 
-	if (!dm_task_add_target(dmt, 0, capacity, "zoned", params))
+	if (!dm_task_add_target (dmt, 0, capacity, "zoned", params))
 		goto out;
 
 	if (dev->flags & DMZ_VERBOSE)
@@ -296,7 +296,7 @@ int dmz_start(struct dmz_dev *dev)
 
 	if (dmz_create_dm(dev)) {
 		fprintf(stderr,
-			"Failed to start %s\n", dev->label);
+			"Failed to start %s", dev->label);
 		return -1;
 	}
 	return 0;

--- a/src/dmz_lib.c
+++ b/src/dmz_lib.c
@@ -48,7 +48,7 @@ int dmz_reset_zone(struct dmz_dev *dev,
 		   struct blk_zone *zone)
 {
 	struct blk_zone_range range;
-	struct dmz_block_dev *bdev = &dev->bdev[0];
+	struct dmz_block_dev *bdev = &dev->bdev[1];
 
 	if (dmz_zone_conv(zone) ||
 	    dmz_zone_empty(zone))
@@ -56,7 +56,7 @@ int dmz_reset_zone(struct dmz_dev *dev,
 
 	/* Non empty sequential zone: reset */
 	range.sector = dmz_zone_sector(zone) -
-		dmz_blk2sect(dev->bdev[0].block_offset);
+		dmz_blk2sect(dev->bdev[1].block_offset);
 	range.nr_sectors = dmz_zone_length(zone);
 	if (ioctl(bdev->fd, BLKRESETZONE, &range) < 0) {
 		fprintf(stderr,

--- a/src/dmzadm.c
+++ b/src/dmzadm.c
@@ -222,38 +222,50 @@ int main(int argc, char **argv)
 	/* Open the device */
 	if (dmz_open_dev(&dev.bdev[0], op, dev.flags) < 0)
 		return 1;
-	if (!dmz_bdev_is_zoned(&dev.bdev[0])) {
-		fprintf(stderr,
-			"%s: Not a zoned block device\n",
-			dev.bdev[0].name);
-		dmz_close_dev(&dev.bdev[0]);
-		return 1;
+	if (dev.bdev[1].path) {
+		if (dmz_bdev_is_zoned(&dev.bdev[0])) {
+			fprintf(stderr,
+				"%s: Not a regular block device\n",
+				dev.bdev[0].name);
+			dmz_close_dev(&dev.bdev[0]);
+			return 1;
+		}
+	} else {
+		if (!dmz_bdev_is_zoned(&dev.bdev[0])) {
+			fprintf(stderr,
+				"%s: Not a zoned block device\n",
+				dev.bdev[0].name);
+			dmz_close_dev(&dev.bdev[0]);
+			return 1;
+		}
+		dev.zone_nr_sectors = dev.bdev[0].zone_nr_sectors;
+		dev.zone_nr_blocks = dev.bdev[0].zone_nr_blocks;
 	}
 	print_dev_info(&dev.bdev[0]);
 	dev.capacity = dev.bdev[0].capacity;
-	dev.zone_nr_sectors = dev.bdev[0].zone_nr_sectors;
-	dev.zone_nr_blocks = dev.bdev[0].zone_nr_blocks;
 
 	if (dev.bdev[1].path) {
 		__u64 nr_zones;
 
 		if (dmz_open_dev(&dev.bdev[1], op, dev.flags) < 0)
 			return 1;
-		if (dmz_bdev_is_zoned(&dev.bdev[1])) {
+		if (!dmz_bdev_is_zoned(&dev.bdev[1])) {
 			fprintf(stderr,
-				"%s: Not a regular block device\n",
+				"%s: Not a zoned block device\n",
 				dev.bdev[1].name);
 			ret = 1;
 			goto out_close;
 		}
 		print_dev_info(&dev.bdev[1]);
 		dev.capacity += dev.bdev[1].capacity;
-		dev.bdev[1].zone_nr_sectors = dev.zone_nr_sectors;
-		dev.bdev[1].zone_nr_blocks = dev.zone_nr_blocks;
-		nr_zones = dev.bdev[1].capacity / dev.zone_nr_sectors;
-		if (dev.bdev[1].capacity % dev.zone_nr_sectors)
+		dev.zone_nr_sectors = dev.bdev[1].zone_nr_sectors;
+		dev.zone_nr_blocks = dev.bdev[1].zone_nr_blocks;
+		dev.bdev[0].zone_nr_sectors = dev.zone_nr_sectors;
+		dev.bdev[0].zone_nr_blocks = dev.zone_nr_blocks;
+		nr_zones = dev.bdev[0].capacity / dev.zone_nr_sectors;
+		if (dev.bdev[0].capacity % dev.zone_nr_sectors)
 			nr_zones++;
-		dev.bdev[0].block_offset = nr_zones * dev.zone_nr_blocks;
+		dev.bdev[1].block_offset = nr_zones * dev.zone_nr_blocks;
 	}
 
 	if (dmz_get_dev_zones(&dev) < 0)


### PR DESCRIPTION
Reshuffle devices such that the regular device is always the first
device to align better with the device-mapper interface.
Also update the documentation to reflect the usage of two devices.

Signed-off-by: Hannes Reinecke <hare@suse.de>