### PR TITLE
Separate 'cache' and 'random' zones

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,10 +31,15 @@ AC_CHECK_HEADER(blkid/blkid.h, [],
 		[AC_MSG_ERROR([Couldn't find blkid/blkid.h])])
 AC_CHECK_HEADER(linux/blkzoned.h, [],
 		[AC_MSG_ERROR([Couldn't find linux/blkzoned.h])])
+AC_CHECK_HEADER(libdevmapper.h, [],
+		[AC_MSG_ERROR([Couldn't find libdevmapper.h])])
 
 # Checks for libraries.
 AC_SEARCH_LIBS([blkid_do_fullprobe], [blkid], [],
 	       [AC_MSG_ERROR([Couldn't find libblkid])])
+
+AC_SEARCH_LIBS([dm_task_run], [devmapper], [],
+		[AC_MSG_ERROR([Couldn't find libdevmapper])])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -31,12 +31,17 @@ AC_CHECK_HEADER(blkid/blkid.h, [],
 		[AC_MSG_ERROR([Couldn't find blkid/blkid.h])])
 AC_CHECK_HEADER(linux/blkzoned.h, [],
 		[AC_MSG_ERROR([Couldn't find linux/blkzoned.h])])
+AC_CHECK_HEADER(uuid/uuid.h, [],
+		[AC_MSG_ERROR([Couldn't find uuid/uuid.h])])
 AC_CHECK_HEADER(libdevmapper.h, [],
 		[AC_MSG_ERROR([Couldn't find libdevmapper.h])])
 
 # Checks for libraries.
 AC_SEARCH_LIBS([blkid_do_fullprobe], [blkid], [],
 	       [AC_MSG_ERROR([Couldn't find libblkid])])
+
+AC_SEARCH_LIBS([uuid_generate_random], [uuid], [],
+		[AC_MSG_ERROR([Couldn't find libuuid])])
 
 AC_SEARCH_LIBS([dm_task_run], [devmapper], [],
 		[AC_MSG_ERROR([Couldn't find libdevmapper])])

--- a/man/dmzadm.8
+++ b/man/dmzadm.8
@@ -53,6 +53,10 @@ Check the zoned block device metadata consistency and try to repair any error
 detected.
 
 .TP
+.B Start
+Load the metadata information from disk and activate the device-mapper target.
+
+.TP
 .B Help
 Print a short usage description of dmzadm
 
@@ -72,6 +76,10 @@ Check a zoned block device metadata.
 .TP
 .BR \-\-repair
 Check a zoned block device metadata and attempt to repair any error found.
+
+.TP
+.BR \-\-start
+Load zoned block device metadata and activate the device-mapper target.
 
 .TP
 .BR \-\-help ", " \-h
@@ -94,6 +102,12 @@ Very detailed output of actions taken.
 .TP
 .BR \-\-seq=<num>
 Specify the number of sequential zones to be reserved for reclaim.
+
+.TP
+.BR \-\-label=<str>
+Sets the name for the device-mapper device. Defaults to
+.I dmz-<devname>
+.
 
 .TP
 .SH AUTHOR

--- a/man/dmzadm.8
+++ b/man/dmzadm.8
@@ -57,6 +57,10 @@ detected.
 Load the metadata information from disk and activate the device-mapper target.
 
 .TP
+.B Stop
+Deactivate the device-mapper target associated with the zoned block device.
+
+.TP
 .B Help
 Print a short usage description of dmzadm
 
@@ -80,6 +84,10 @@ Check a zoned block device metadata and attempt to repair any error found.
 .TP
 .BR \-\-start
 Load zoned block device metadata and activate the device-mapper target.
+
+.TP
+.BR \-\-start
+Deactivate the device-mapper target for a zoned block device.
 
 .TP
 .BR \-\-help ", " \-h

--- a/man/dmzadm.8
+++ b/man/dmzadm.8
@@ -92,7 +92,7 @@ Very detailed output of actions taken.
 \fIFormat\fP operation options:
 
 .TP
-.BR \-\-seq <num>
+.BR \-\-seq=<num>
 Specify the number of sequential zones to be reserved for reclaim.
 
 .TP

--- a/man/dmzadm.8
+++ b/man/dmzadm.8
@@ -12,7 +12,7 @@ mapper
 .I operation
 >
 <
-.I zoned-block-device
+.I [regular-block-device] zoned-block-device
 >
 [
 .I options
@@ -22,9 +22,11 @@ mapper
 .B dmzadm
 is used to format, check and repair a zoned block device used with the dm-zoned
 device mapper. 
-\fIzoned-block-device\fP is the special file corresponding to the target zoned
+\fIzoned-block-device\fP is the device node corresponding to the target zoned
 blocks device (e.g.
 \fI/dev/sdXX\fP).
+\fIregular-block-device\fP is the optional device node corresponding to a
+regular block device to be used together with the zoned block devoce.
 \fIoperation\fP specifies the action to be taken for the device.
 .PP
 The exit code returned by
@@ -37,28 +39,29 @@ dmzadm allows the following operations.
 
 .TP
 .B Format
-Write to the zoned block device dm-zoned metadata, whiping clean all data that
-was stored on the device.
+Write to the zoned block device and optional regular block device dm-zoned
+metadata, whiping clean all data that was stored on the device.
 
 .TP
 .B Check
-Check the zoned block device metadata consistency. No repair action is taken.
+Check the device(s) metadata consistency. No repair action is taken.
 Errors are not corrected with this operation. For repairing incorrect metadata,
 the
 \fIRepair\fP operation must be used.
 
 .TP
 .B Repair
-Check the zoned block device metadata consistency and try to repair any error
+Check the device metadata consistency and try to repair any error
 detected.
 
 .TP
 .B Start
-Load the metadata information from disk and activate the device-mapper target.
+Load the metadata information from disk(s) and activate the device-mapper
+target.
 
 .TP
 .B Stop
-Deactivate the device-mapper target associated with the zoned block device.
+Deactivate the device-mapper target associated with the block device(s).
 
 .TP
 .B Help
@@ -71,22 +74,22 @@ Options for selecting an operation are:
 
 .TP
 .BR \-\-format
-Format a zoned block device.
+Format the specified block device(s).
 
 .TP
 .BR \-\-check
-Check a zoned block device metadata.
+Check the specified block device(s) metadata.
 
 .TP
 .BR \-\-repair
-Check a zoned block device metadata and attempt to repair any error found.
+Check the block device(s) metadata and attempt to repair any error found.
 
 .TP
 .BR \-\-start
-Load zoned block device metadata and activate the device-mapper target.
+Load block device(s) metadata and activate the device-mapper target.
 
 .TP
-.BR \-\-start
+.BR \-\-stop
 Deactivate the device-mapper target for a zoned block device.
 
 .TP

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,6 +7,7 @@ CFILES = dmz_dev.c \
 	 dmz_lib.c \
 	 dmz_format.c \
 	 dmz_check.c \
+	 dmz_devmapper.c \
 	 dmzadm.c
 HFILES = dmz.h
 

--- a/src/dmz.h
+++ b/src/dmz.h
@@ -139,7 +139,7 @@ struct dm_zoned_map {
  */
 #define DMZ_VERBOSE		0x00000001
 #define DMZ_VVERBOSE		0x00000002
-#define DMZ_REPAIR  		0x00000004
+#define DMZ_REPAIR		0x00000004
 #define DMZ_ZONED_HA		0x00000010
 #define DMZ_ZONED_HM		0x00000020
 #define DMZ_OVERWRITE		0x00000040
@@ -213,17 +213,17 @@ struct dmz_meta_set {
 	int		id;
 	unsigned int	flags;
 
-	__u64 		sb_block;
+	__u64		sb_block;
 	__u64		map_block;
 	__u64		bitmap_block;
 
-	__u8 		buf[DMZ_BLOCK_SIZE];
-	__u8 		*map_buf;
+	__u8		buf[DMZ_BLOCK_SIZE];
+	__u8		*map_buf;
 
-	__u64 		gen;
+	__u64		gen;
 
-	unsigned int 	nr_mapped_chunks;
-	unsigned int 	nr_buf_chunks;
+	unsigned int	nr_mapped_chunks;
+	unsigned int	nr_buf_chunks;
 
 	unsigned int	error_count;
 	unsigned int	total_error_count;
@@ -263,7 +263,7 @@ static inline void dmz_clear_bit(__u8 *bitmap,
 #define dmz_dev_is_hm(dev)	((dev)->flags & DMZ_ZONED_HM)
 #define dmz_dev_is_zoned(dev)	(dmz_dev_is_ha(dev) || dmz_dev_is_hm(dev))
 
-#define dmz_zone_type(z)        (z)->type
+#define dmz_zone_type(z)	(z)->type
 #define dmz_zone_conv(z)	((z)->type == BLK_ZONE_TYPE_CONVENTIONAL)
 #define dmz_zone_seq_req(z)	((z)->type == BLK_ZONE_TYPE_SEQWRITE_REQ)
 #define dmz_zone_seq_pref(z)	((z)->type == BLK_ZONE_TYPE_SEQWRITE_PREF)

--- a/src/dmz.h
+++ b/src/dmz.h
@@ -151,6 +151,7 @@ enum dmz_op {
 	DMZ_OP_FORMAT = 1,
 	DMZ_OP_CHECK,
 	DMZ_OP_REPAIR,
+	DMZ_OP_START,
 };
 
 /*
@@ -163,6 +164,7 @@ struct dmz_dev {
 	char		*name;
 	int		op;
 	unsigned int	flags;
+	char		label[32];
 
 	/* Device info */
 	__u64		capacity;
@@ -332,5 +334,6 @@ extern int dmz_format(struct dmz_dev *dev);
 extern int dmz_check(struct dmz_dev *dev);
 extern int dmz_repair(struct dmz_dev *dev);
 extern int dmz_init_dm(int log_level);
+extern int dmz_start(struct dmz_dev *dev);
 
 #endif /* __DMZ_H__ */

--- a/src/dmz.h
+++ b/src/dmz.h
@@ -184,6 +184,7 @@ struct dmz_dev {
 	size_t		zone_nr_blocks;
 
 	/* First metadata zone */
+	unsigned int	sb_version;
 	struct blk_zone	*sb_zone;
 	__u64		sb_block;
 
@@ -330,5 +331,6 @@ extern int dmz_write_super(struct dmz_dev *dev, __u64 gen, __u64 offset);
 extern int dmz_format(struct dmz_dev *dev);
 extern int dmz_check(struct dmz_dev *dev);
 extern int dmz_repair(struct dmz_dev *dev);
+extern int dmz_init_dm(int log_level);
 
 #endif /* __DMZ_H__ */

--- a/src/dmz.h
+++ b/src/dmz.h
@@ -152,6 +152,7 @@ enum dmz_op {
 	DMZ_OP_CHECK,
 	DMZ_OP_REPAIR,
 	DMZ_OP_START,
+	DMZ_OP_STOP,
 };
 
 /*
@@ -320,6 +321,7 @@ dmz_zone_cond_str(struct blk_zone *zone)
 
 extern int dmz_open_dev(struct dmz_dev *dev, enum dmz_op op);
 extern void dmz_close_dev(struct dmz_dev *dev);
+extern int dmz_get_dev_holder(struct dmz_dev *dev, char *holder);
 extern int dmz_sync_dev(struct dmz_dev *dev);
 extern int dmz_reset_zone(struct dmz_dev *dev, struct blk_zone *zone);
 extern int dmz_reset_zones(struct dmz_dev *dev);
@@ -335,5 +337,6 @@ extern int dmz_check(struct dmz_dev *dev);
 extern int dmz_repair(struct dmz_dev *dev);
 extern int dmz_init_dm(int log_level);
 extern int dmz_start(struct dmz_dev *dev);
+extern int dmz_stop(struct dmz_dev *dev, char *dm_dev);
 
 #endif /* __DMZ_H__ */

--- a/src/dmz_check.c
+++ b/src/dmz_check.c
@@ -1030,7 +1030,7 @@ static int dmz_check_superblocks(struct dmz_dev *dev,
 		return -1;
 
 	if (dev->bdev[1].name) {
-		mset[2].sb_block = dev->bdev[0].block_offset;
+		mset[2].sb_block = dev->bdev[1].block_offset;
 		dmz_msg(dev, ind,
 			"Tertiary superblock at block %llu (zone %u)\n",
 			mset[2].sb_block,

--- a/src/dmz_check.c
+++ b/src/dmz_check.c
@@ -1240,7 +1240,7 @@ int dmz_repair(struct dmz_dev *dev)
 	}
 
 	/* Sync device */
-	if (dmz_sync_dev(dev) < 0)
+	if (dmz_sync_dev(&dev->bdev[0]) < 0)
 		return -1;
 
 	return 0;

--- a/src/dmz_dev.c
+++ b/src/dmz_dev.c
@@ -491,6 +491,43 @@ int dmz_open_dev(struct dmz_dev *dev, enum dmz_op op)
 }
 
 /*
+ * Get the holder of a device
+ */
+int dmz_get_dev_holder(struct dmz_dev *dev, char *holder)
+{
+	struct stat st;
+
+	dev->name = basename(dev->path);
+
+	/* Check that this is a block device */
+	if (stat(dev->path, &st) < 0) {
+		fprintf(stderr,
+			"Get %s stat failed %d (%s)\n",
+			dev->path,
+			errno, strerror(errno));
+		return -1;
+	}
+
+	if (!S_ISBLK(st.st_mode)) {
+		fprintf(stderr,
+			"%s is not a block device\n",
+			dev->path);
+		return -1;
+	}
+
+	if (dmz_dev_mounted(dev)) {
+		fprintf(stderr,
+			"%s is mounted\n",
+			dev->path);
+		return -1;
+	}
+
+	if (!dmz_dev_busy(dev, holder))
+		memset(holder, 0, PATH_MAX);
+	return 0;
+}
+
+/*
  * Close an open device.
  */
 void dmz_close_dev(struct dmz_dev *dev)

--- a/src/dmz_dev.c
+++ b/src/dmz_dev.c
@@ -33,6 +33,32 @@
 
 #include <blkid/blkid.h>
 
+
+/*
+ * Translate device to block
+ */
+struct dmz_block_dev *
+dmz_block_to_bdev(struct dmz_dev *dev, __u64 block, __u64 *ret_block)
+{
+	*ret_block = block;
+	if (!dev->bdev[1].name)
+		return &dev->bdev[0];
+
+	if (block < dev->bdev[0].block_offset)
+		return &dev->bdev[1];
+
+	*ret_block -= dev->bdev[0].block_offset;
+	return &dev->bdev[0];
+}
+
+unsigned int dmz_block_zone_id(struct dmz_dev *dev, __u64 block)
+{
+	unsigned int zone_id;
+
+	zone_id = block / dev->zone_nr_blocks;
+	return zone_id;
+}
+
 /*
  * Test if the device is mounted.
  */
@@ -92,7 +118,7 @@ static int dmz_dev_busy(struct dmz_block_dev *dev, char *holder)
  */
 static int dmz_get_dev_model(struct dmz_block_dev *dev)
 {
-	char str[PATH_MAX];
+	char str[PATH_MAX] = {};
 	FILE *file;
 	int res;
 	int len;
@@ -127,6 +153,8 @@ static int dmz_get_dev_model(struct dmz_block_dev *dev)
 		dev->type = DMZ_TYPE_ZONED_HA;
 	else if (strcmp(str, "host-managed") == 0)
 		dev->type = DMZ_TYPE_ZONED_HM;
+	else
+		dev->type = DMZ_TYPE_REGULAR;
 
 	return 0;
 }
@@ -148,6 +176,9 @@ static int dmz_get_dev_capacity(struct dmz_block_dev *dev)
 		return -1;
 	}
 	dev->capacity >>= 9;
+
+	if (dev->type == DMZ_TYPE_REGULAR)
+		return 0;
 
 	/* Get zone size */
 	snprintf(str, sizeof(str),
@@ -234,7 +265,7 @@ static void dmz_print_zone(struct dmz_dev *dev,
  */
 int dmz_get_dev_zones(struct dmz_dev *dev)
 {
-	struct dmz_block_dev *bdev = &dev->bdev[0];
+	struct dmz_block_dev *bdev;
 	struct blk_zone_report *rep = NULL;
 	unsigned int rep_max_zones;
 	struct blk_zone *blkz;
@@ -266,10 +297,38 @@ int dmz_get_dev_zones(struct dmz_dev *dev)
 
 	sector = 0;
 	while (sector < dev->capacity) {
+		__u64 sector_offset = dmz_blk2sect(dev->bdev[0].block_offset);
+		__u64 bdev_sector;
 
+		if (!dev->bdev[1].name) {
+			bdev = &dev->bdev[0];
+			bdev_sector = sector;
+		} else if (sector < sector_offset) {
+			bdev = &dev->bdev[1];
+			bdev_sector = sector;
+		} else {
+			bdev = &dev->bdev[0];
+			bdev_sector = sector - sector_offset;
+		}
+		if (bdev->type == DMZ_TYPE_REGULAR) {
+			__u64 zone_len = dev->zone_nr_sectors;
+
+			/* Emulate zone information */
+			blkz = &dev->zones[dev->nr_zones];
+			blkz->start = sector;
+			if (blkz->start + zone_len > bdev->capacity)
+				zone_len = bdev->capacity - blkz->start;
+			blkz->len = zone_len;
+			blkz->wp = (__u64)-1;
+			blkz->type = BLK_ZONE_TYPE_CONVENTIONAL;
+			blkz->cond = BLK_ZONE_COND_NOT_WP;
+			dev->nr_zones++;
+			sector += dev->zone_nr_sectors;
+			continue;
+		}
 		/* Get zone information */
 		memset(rep, 0, DMZ_REPORT_ZONES_BUFSZ);
-		rep->sector = sector;
+		rep->sector = bdev_sector;
 		rep->nr_zones = rep_max_zones;
 		ret = ioctl(bdev->fd, BLKREPORTZONE, rep);
 		if (ret != 0) {
@@ -299,6 +358,8 @@ int dmz_get_dev_zones(struct dmz_dev *dev)
 				goto out;
 			}
 
+			blkz->start += sector_offset;
+			blkz->wp += sector_offset;
 			dev->zones[dev->nr_zones] = *blkz;
 			dev->nr_zones++;
 
@@ -309,21 +370,21 @@ int dmz_get_dev_zones(struct dmz_dev *dev)
 
 	}
 
-	if (sector != dev->capacity) {
-		fprintf(stderr,
-			"%s: Invalid zones (last sector reported is %llu, "
-			"expected %llu)\n",
-			dev->label,
-			sector, dev->capacity);
-		ret = -1;
-		goto out;
-	}
-
 	if (dev->nr_zones != nr_zones) {
 		fprintf(stderr,
 			"%s: Invalid number of zones (expected %u, got %u)\n",
 			dev->label,
 			nr_zones, dev->nr_zones);
+		ret = -1;
+		goto out;
+	}
+
+	if (sector != dev->nr_zones * dev->zone_nr_sectors) {
+		fprintf(stderr,
+			"%s: Invalid zones (last sector reported is %llu, "
+			"expected %llu)\n",
+			dev->label,
+			sector, dev->capacity);
 		ret = -1;
 		goto out;
 	}
@@ -341,13 +402,6 @@ static int dmz_get_dev_info(struct dmz_block_dev *dev)
 {
 	if (dmz_get_dev_model(dev) < 0)
 		return -1;
-
-	if (!dmz_bdev_is_zoned(dev)) {
-		fprintf(stderr,
-			"%s: Not a zoned block device\n",
-			dev->name);
-		return -1;
-	}
 
 	if (dmz_get_dev_capacity(dev) < 0)
 		return -1;
@@ -539,17 +593,19 @@ void dmz_close_dev(struct dmz_block_dev *dev)
  */
 int dmz_read_block(struct dmz_dev *dev, __u64 block, __u8 *buf)
 {
-	struct dmz_block_dev *bdev = &dev->bdev[0];
+	__u64 read_block;
+	struct dmz_block_dev *bdev =
+		dmz_block_to_bdev(dev, block, &read_block);
 	ssize_t ret;
 
-	ret = pread(bdev->fd, (char *)buf,
-		    DMZ_BLOCK_SIZE, block << DMZ_BLOCK_SHIFT);
+	ret = pread(bdev->fd, (char *)buf, DMZ_BLOCK_SIZE,
+		    read_block << DMZ_BLOCK_SHIFT);
 
 	if (ret != DMZ_BLOCK_SIZE) {
 		fprintf(stderr,
 			"%s: Read block %llu failed %d (%s)\n",
 			bdev->name,
-			block,
+			read_block,
 			errno, strerror(errno));
 		return -1;
 	}
@@ -562,11 +618,13 @@ int dmz_read_block(struct dmz_dev *dev, __u64 block, __u8 *buf)
  */
 int dmz_write_block(struct dmz_dev *dev, __u64 block, __u8 *buf)
 {
-	struct dmz_block_dev *bdev = &dev->bdev[0];
+	__u64 write_block;
+	struct dmz_block_dev *bdev =
+		dmz_block_to_bdev(dev, block, &write_block);
 	ssize_t ret;
 
-	ret = pwrite(bdev->fd, (char *)buf,
-		     DMZ_BLOCK_SIZE, block << DMZ_BLOCK_SHIFT);
+	ret = pwrite(bdev->fd, (char *)buf, DMZ_BLOCK_SIZE,
+		     write_block << DMZ_BLOCK_SHIFT);
 	if (ret != DMZ_BLOCK_SIZE) {
 		fprintf(stderr,
 			"%s: Write block %llu failed %d (%s)\n",

--- a/src/dmz_dev.c
+++ b/src/dmz_dev.c
@@ -44,11 +44,11 @@ dmz_block_to_bdev(struct dmz_dev *dev, __u64 block, __u64 *ret_block)
 	if (!dev->bdev[1].name)
 		return &dev->bdev[0];
 
-	if (block < dev->bdev[0].block_offset)
-		return &dev->bdev[1];
+	if (block < dev->bdev[1].block_offset)
+		return &dev->bdev[0];
 
-	*ret_block -= dev->bdev[0].block_offset;
-	return &dev->bdev[0];
+	*ret_block -= dev->bdev[1].block_offset;
+	return &dev->bdev[1];
 }
 
 unsigned int dmz_block_zone_id(struct dmz_dev *dev, __u64 block)
@@ -297,17 +297,17 @@ int dmz_get_dev_zones(struct dmz_dev *dev)
 
 	sector = 0;
 	while (sector < dev->capacity) {
-		__u64 sector_offset = dmz_blk2sect(dev->bdev[0].block_offset);
+		__u64 sector_offset = dmz_blk2sect(dev->bdev[1].block_offset);
 		__u64 bdev_sector;
 
 		if (!dev->bdev[1].name) {
 			bdev = &dev->bdev[0];
 			bdev_sector = sector;
 		} else if (sector < sector_offset) {
-			bdev = &dev->bdev[1];
+			bdev = &dev->bdev[0];
 			bdev_sector = sector;
 		} else {
-			bdev = &dev->bdev[0];
+			bdev = &dev->bdev[1];
 			bdev_sector = sector - sector_offset;
 		}
 		if (bdev->type == DMZ_TYPE_REGULAR) {

--- a/src/dmz_dev.c
+++ b/src/dmz_dev.c
@@ -320,7 +320,7 @@ int dmz_get_dev_zones(struct dmz_dev *dev)
 				zone_len = bdev->capacity - blkz->start;
 			blkz->len = zone_len;
 			blkz->wp = (__u64)-1;
-			blkz->type = BLK_ZONE_TYPE_CONVENTIONAL;
+			blkz->type = BLK_ZONE_TYPE_UNKNOWN;
 			blkz->cond = BLK_ZONE_COND_NOT_WP;
 			dev->nr_zones++;
 			sector += dev->zone_nr_sectors;

--- a/src/dmz_dev.c
+++ b/src/dmz_dev.c
@@ -57,7 +57,7 @@ static int dmz_dev_mounted(struct dmz_dev *dev)
 /*
  * Test if the device is already used as a target backend.
  */
-static int dmz_dev_busy(struct dmz_dev *dev)
+static int dmz_dev_busy(struct dmz_dev *dev, char *holder)
 {
 	char path[128];
 	struct dirent **namelist;
@@ -75,8 +75,11 @@ static int dmz_dev_busy(struct dmz_dev *dev)
 
 	while (n--) {
 		if (strcmp(namelist[n]->d_name, "..") != 0 &&
-		    strcmp(namelist[n]->d_name, ".") != 0)
+		    strcmp(namelist[n]->d_name, ".") != 0) {
+			if (holder)
+				strncpy(holder, namelist[n]->d_name, PATH_MAX);
 			ret = 1;
+		}
 		free(namelist[n]);
 	}
 	free(namelist);
@@ -461,7 +464,7 @@ int dmz_open_dev(struct dmz_dev *dev, enum dmz_op op)
 		return -1;
 	}
 
-	if (dmz_dev_busy(dev)) {
+	if (dmz_dev_busy(dev, NULL)) {
 		fprintf(stderr,
 			"%s is in use\n",
 			dev->path);

--- a/src/dmz_devmapper.c
+++ b/src/dmz_devmapper.c
@@ -88,18 +88,18 @@ int dmz_create_dm(struct dmz_dev *dev)
 	 */
 	capacity = dev->nr_chunks * dev->zone_nr_sectors;
 
-	if (!(dmt = dm_task_create (DM_DEVICE_CREATE)))
+	if (!(dmt = dm_task_create(DM_DEVICE_CREATE)))
 		return -ENOMEM;
 
-	if (!dm_task_set_name (dmt, dev->label))
+	if (!dm_task_set_name(dmt, dev->label))
 		goto out;
 
 	if (dev->sb_version > 1 && dev->bdev[1].path)
-		sprintf(params, "%s %s", dev->bdev[0].path, dev->bdev[1].path);
+		sprintf(params, "%s %s", dev->bdev[1].path, dev->bdev[0].path);
 	else
 		sprintf(params, "%s", dev->bdev[0].path);
 
-	if (!dm_task_add_target (dmt, 0, capacity, "zoned", params))
+	if (!dm_task_add_target(dmt, 0, capacity, "zoned", params))
 		goto out;
 
 	if (dev->flags & DMZ_VERBOSE)

--- a/src/dmz_devmapper.c
+++ b/src/dmz_devmapper.c
@@ -55,8 +55,8 @@ int dmz_init_dm(int log_level)
 				       tgt->version[0], tgt->version[1],
 				       tgt->version[2]);
 			ret = 0;
-			if (tgt->version[0] == 1) {
-				ret = tgt->version[1];
+			if (tgt->version[0] == 1 || tgt->version[0] == 2) {
+				ret = tgt->version[0];
 				break;
 			}
 			fprintf(stderr,

--- a/src/dmz_devmapper.c
+++ b/src/dmz_devmapper.c
@@ -114,6 +114,68 @@ out:
 	return ret;
 }
 
+int dmz_check_dm_target(struct dmz_dev *dev, char *dm_dev)
+{
+	int ret = -EINVAL;
+	struct dm_task *dmt;
+	uint64_t start, length;
+	char *target_type, *params;
+
+	if (!(dmt = dm_task_create (DM_DEVICE_TABLE)))
+		return -ENOMEM;
+
+	if (!dm_task_set_name (dmt, dm_dev)) {
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	dm_task_no_open_count(dmt);
+
+	if (!dm_task_run (dmt)) {
+		ret = -EINVAL;
+		goto out;
+	}
+	dm_get_next_target(dmt, NULL, &start, &length,
+			   &target_type, &params);
+	if (strlen(target_type) == 5 &&
+	    !strncmp(target_type, "zoned", 5)) {
+		strcpy(dev->label, dm_task_get_name(dmt));
+		ret = 0;
+	}
+out:
+	dm_task_destroy(dmt);
+
+	return ret;
+}
+
+int dmz_deactivate_dm(char *dm_dev)
+{
+	int ret = -EINVAL;
+	struct dm_task *dmt;
+	uint32_t cookie = 0;
+	__u16 udev_flags = DM_UDEV_DISABLE_LIBRARY_FALLBACK;
+
+	if (!(dmt = dm_task_create (DM_DEVICE_REMOVE)))
+		return -ENOMEM;
+
+	if (!dm_task_set_name (dmt, dm_dev)) {
+		goto out;
+	}
+
+	dm_task_no_open_count(dmt);
+
+	if (dm_task_set_cookie(dmt, &cookie, udev_flags)) {
+		if (dm_task_run (dmt)) {
+			dm_udev_wait(cookie);
+			ret = 0;
+		}
+	}
+out:
+	dm_task_destroy(dmt);
+
+	return ret;
+}
+
 /*
  * Load the contents of a super block
  */
@@ -200,6 +262,39 @@ int dmz_start(struct dmz_dev *dev)
 		fprintf(stderr,
 			"Failed to start %s", dev->label);
 		return -1;
+	}
+	return 0;
+}
+
+int dmz_stop(struct dmz_dev *dev, char *dm_name)
+{
+	int ret, log_level = 0;
+	char dm_dev[PATH_MAX];
+
+	dm_log_with_errno_init(NULL);
+
+	if (dev->flags & DMZ_VVERBOSE)
+		log_level++;
+	dm_log_init_verbose(log_level);
+
+	sprintf(dm_dev, "/dev/%s", dm_name);
+	ret = dmz_check_dm_target(dev, dm_dev);
+	if (ret < 0) {
+		fprintf(stderr,
+			"%s: dm device %s is not a zoned target device\n",
+			dev->name, dm_name);
+		return ret;
+	}
+
+	printf("%s: stopping %s\n",
+	       dev->name, dev->label);
+
+	ret = dmz_deactivate_dm(dm_dev);
+	if (ret < 0) {
+		fprintf(stderr,
+			"%s: could not deactivate %s\n",
+			dev->name, dev->label);
+		return ret;
 	}
 	return 0;
 }

--- a/src/dmz_devmapper.c
+++ b/src/dmz_devmapper.c
@@ -55,7 +55,7 @@ int dmz_init_dm(int log_level)
 				       tgt->version[0], tgt->version[1],
 				       tgt->version[2]);
 			ret = 0;
-			if (tgt->version[0] == 1 || tgt->version[0] == 2) {
+			if (tgt->version[0] <= DMZ_META_VER) {
 				ret = tgt->version[0];
 				break;
 			}
@@ -88,18 +88,18 @@ int dmz_create_dm(struct dmz_dev *dev)
 	 */
 	capacity = dev->nr_chunks * dev->zone_nr_sectors;
 
-	if (!(dmt = dm_task_create(DM_DEVICE_CREATE)))
+	if (!(dmt = dm_task_create (DM_DEVICE_CREATE)))
 		return -ENOMEM;
 
-	if (!dm_task_set_name(dmt, dev->label))
+	if (!dm_task_set_name (dmt, dev->label))
 		goto out;
 
 	if (dev->sb_version > 1 && dev->bdev[1].path)
-		sprintf(params, "%s %s", dev->bdev[1].path, dev->bdev[0].path);
+		sprintf(params, "%s %s", dev->bdev[0].path, dev->bdev[1].path);
 	else
 		sprintf(params, "%s", dev->bdev[0].path);
 
-	if (!dm_task_add_target(dmt, 0, capacity, "zoned", params))
+	if (!dm_task_add_target (dmt, 0, capacity, "zoned", params))
 		goto out;
 
 	if (dev->flags & DMZ_VERBOSE)
@@ -296,7 +296,7 @@ int dmz_start(struct dmz_dev *dev)
 
 	if (dmz_create_dm(dev)) {
 		fprintf(stderr,
-			"Failed to start %s\n", dev->label);
+			"Failed to start %s", dev->label);
 		return -1;
 	}
 	return 0;

--- a/src/dmz_devmapper.c
+++ b/src/dmz_devmapper.c
@@ -296,7 +296,7 @@ int dmz_start(struct dmz_dev *dev)
 
 	if (dmz_create_dm(dev)) {
 		fprintf(stderr,
-			"Failed to start %s", dev->label);
+			"Failed to start %s\n", dev->label);
 		return -1;
 	}
 	return 0;

--- a/src/dmz_devmapper.c
+++ b/src/dmz_devmapper.c
@@ -72,3 +72,134 @@ int dmz_init_dm(int log_level)
 		fprintf(stderr, "dm-zoned target not supported\n");
 	return ret;
 }
+
+int dmz_create_dm(struct dmz_dev *dev)
+{
+	int ret = -EINVAL;
+	struct dm_task *dmt;
+	uint32_t cookie = 0;
+	__u64 capacity = dev->nr_zones * dev->zone_nr_sectors;
+	__u16 udev_flags = DM_UDEV_DISABLE_LIBRARY_FALLBACK;
+	char params[4096];
+
+	if (!(dmt = dm_task_create (DM_DEVICE_CREATE)))
+		return -ENOMEM;
+
+	if (!dm_task_set_name (dmt, dev->label))
+		goto out;
+
+	sprintf(params, "%s", dev->path);
+
+	if (!dm_task_add_target (dmt, 0, capacity, "zoned", params))
+		goto out;
+
+	if (dev->flags & DMZ_VERBOSE)
+		printf("%s: table 0 %llu zoned %s\n", dev->name,
+		       capacity, params);
+
+	dm_task_skip_lockfs(dmt);
+	dm_task_no_flush(dmt);
+	dm_task_no_open_count(dmt);
+
+	if (dm_task_set_cookie(dmt, &cookie, udev_flags)) {
+		if (dm_task_run (dmt)) {
+			dm_udev_wait(cookie);
+			ret = 0;
+		}
+	}
+
+out:
+	dm_task_destroy(dmt);
+
+	return ret;
+}
+
+/*
+ * Load the contents of a super block
+ */
+static int dmz_load_sb(struct dmz_dev *dev)
+{
+	struct dm_zoned_super *sb;
+	unsigned char *buf;
+	__u32 stored_crc, calculated_crc;
+	int ret;
+
+	buf = malloc(DMZ_BLOCK_SIZE);
+	if (!buf)
+		return -ENOMEM;
+
+	sb = (struct dm_zoned_super *)buf;
+	ret = dmz_read_block(dev, dev->sb_block, buf);
+	if (ret != 0) {
+		ret = -EIO;
+		goto out;
+	}
+
+	/* Check magic */
+	if (__le32_to_cpu(sb->magic) != DMZ_MAGIC) {
+		fprintf(stderr,
+			"%s: invalid magic (expected 0x%08x read 0x%08x)\n",
+			dev->name, DMZ_MAGIC, __le32_to_cpu(sb->magic));
+		ret = -EINVAL;
+		goto out;
+	}
+
+	/* Check CRC */
+	stored_crc = __le32_to_cpu(sb->crc);
+	sb->crc = 0;
+	calculated_crc = dmz_crc32(sb->gen, buf, DMZ_BLOCK_SIZE);
+	if (calculated_crc != stored_crc) {
+		fprintf(stderr,
+			"%s: invalid crc (expected 0x%08x, read 0x%08x)\n",
+			dev->name, calculated_crc, stored_crc);
+		ret = -EINVAL;
+		goto out;
+	}
+
+	/* OK */
+	if (dev->flags & DMZ_VERBOSE)
+		printf("%s: loaded superblock (version %d, generation %llu)\n",
+		       dev->name, __le32_to_cpu(sb->version),
+		       __le64_to_cpu(sb->gen));
+
+out:
+	free(sb);
+	return ret;
+}
+
+int dmz_start(struct dmz_dev *dev)
+{
+	/* Calculate metadata location */
+	if (dev->flags & DMZ_VERBOSE)
+		printf("Locating metadata...\n");
+	if (dmz_locate_metadata(dev) < 0) {
+		fprintf(stderr,
+			"Failed to locate metadata\n");
+		return -1;
+	}
+
+	/* Check primary super block */
+	if (dev->flags & DMZ_VERBOSE)
+		printf("Primary metadata set at block %llu (zone %u)\n",
+		       dev->sb_block, dmz_zone_id(dev, dev->sb_zone));
+
+	if (dmz_load_sb(dev) < 0) {
+		fprintf(stderr,
+			"Failed to load metadata\n");
+		return -1;
+	}
+
+	/* Generate dm name if not set */
+	if (!strlen(dev->label))
+		sprintf(dev->label, "dmz-%s", dev->name);
+
+	printf("%s: starting %s\n",
+	       dev->name, dev->label);
+
+	if (dmz_create_dm(dev)) {
+		fprintf(stderr,
+			"Failed to start %s", dev->label);
+		return -1;
+	}
+	return 0;
+}

--- a/src/dmz_devmapper.c
+++ b/src/dmz_devmapper.c
@@ -1,0 +1,74 @@
+/*
+ * This file is part of dm-zoned tools.
+ *
+ * Copyright (C) 2020, SUSE Linux. All rights reserved.
+ *
+ * This software is distributed under the terms of the BSD 2-clause license,
+ * "as is," without technical support, and WITHOUT ANY WARRANTY, without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. You should have received a copy of the BSD 2-clause license along
+ * with dm-zoned tools.
+ * If not, see <http://opensource.org/licenses/BSD-2-Clause>.
+ *
+ * Authors: Hannes Reinecke (hare@suse.com)
+ */
+
+#include "dmz.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+#include <asm/byteorder.h>
+
+#include <libdevmapper.h>
+
+int dmz_init_dm(int log_level)
+{
+	struct dm_task *dmt;
+	struct dm_versions *tgt, *last_tgt;
+	int ret = -ENXIO;
+
+	dm_log_with_errno_init(NULL);
+
+	if (log_level > 1)
+		dm_log_init_verbose(log_level - 1);
+
+	if (!(dmt = dm_task_create(DM_DEVICE_LIST_VERSIONS)))
+		return -ENOMEM;
+
+	dm_task_no_open_count(dmt);
+
+	if (!dm_task_run(dmt)) {
+		fprintf(stderr, "Failed to communicated with device-mapper\n");
+		return -ENODEV;
+	}
+
+	tgt = dm_task_get_versions(dmt);
+	do {
+		last_tgt = tgt;
+		if (!strncmp("zoned", tgt->name, 5)) {
+			if (log_level)
+				printf("Found dm-zoned version %d.%d.%d\n",
+				       tgt->version[0], tgt->version[1],
+				       tgt->version[2]);
+			ret = 0;
+			if (tgt->version[0] == 1) {
+				ret = tgt->version[1];
+				break;
+			}
+			fprintf(stderr,
+				"Unsupported dm-zoned version %d.%d.%d\n",
+				tgt->version[0], tgt->version[1],
+				tgt->version[2]);
+		}
+		tgt = (void *) tgt + tgt->next;
+	} while (last_tgt != tgt);
+
+	dm_task_destroy(dmt);
+	if (ret < 0)
+		fprintf(stderr, "dm-zoned target not supported\n");
+	return ret;
+}

--- a/src/dmz_format.c
+++ b/src/dmz_format.c
@@ -47,10 +47,10 @@ int dmz_write_super(struct dmz_dev *dev,
 
 	bdev_sb_block = sb_block;
 	if (dev->bdev[1].name) {
-		if (sb_block >= dev->bdev[0].block_offset)
-			bdev_sb_block -= dev->bdev[0].block_offset;
-		else
+		if (sb_block >= dev->bdev[1].block_offset) {
+			bdev_sb_block -= dev->bdev[1].block_offset;
 			bdev = &dev->bdev[1];
+		}
 	}
 
 	printf("  Writing super block to %s block %llu\n",
@@ -303,7 +303,7 @@ int dmz_format(struct dmz_dev *dev)
 
 	if (dev->sb_version > 1 && dev->bdev[1].name) {
 		printf("Writing tertiary metadata\n");
-		if (dmz_write_super(dev, 0, dev->bdev[0].block_offset) < 0)
+		if (dmz_write_super(dev, 0, dev->bdev[1].block_offset) < 0)
 			return -1;
 	}
 

--- a/src/dmz_format.c
+++ b/src/dmz_format.c
@@ -31,7 +31,7 @@
 int dmz_write_super(struct dmz_dev *dev,
 		    __u64 gen, __u64 offset)
 {
-	__u64 sb_block = dev->sb_block + offset;
+	__u64 sb_block = dev->sb_block + offset, bdev_sb_block;
 	struct dm_zoned_super *sb;
 	struct dmz_block_dev *bdev = &dev->bdev[0];
 	__u32 crc;
@@ -45,10 +45,21 @@ int dmz_write_super(struct dmz_dev *dev,
 	}
 	memset(buf, 0, DMZ_BLOCK_SIZE);
 
+	bdev_sb_block = sb_block;
+	if (dev->bdev[1].name) {
+		if (sb_block >= dev->bdev[0].block_offset)
+			bdev_sb_block -= dev->bdev[0].block_offset;
+		else
+			bdev = &dev->bdev[1];
+	}
+
+	printf("  Writing super block to %s block %llu\n",
+	       bdev->name, bdev_sb_block);
+
 	sb = (struct dm_zoned_super *) buf;
 
 	sb->magic = __cpu_to_le32(DMZ_MAGIC);
-	sb->version = __cpu_to_le32(DMZ_META_VER);
+	sb->version = __cpu_to_le32(dev->sb_version);
 
 	sb->gen = __cpu_to_le64(gen);
 
@@ -60,6 +71,11 @@ int dmz_write_super(struct dmz_dev *dev,
 	sb->nr_map_blocks = __cpu_to_le32(dev->nr_map_blocks);
 	sb->nr_bitmap_blocks = __cpu_to_le32(dev->nr_bitmap_blocks);
 
+	if (dev->sb_version > 1) {
+		memcpy(sb->dmz_uuid, dev->uuid, 16);
+		memcpy(sb->dmz_label, dev->label, 32);
+		memcpy(sb->dev_uuid, bdev->uuid, 16);
+	}
 	crc = dmz_crc32(gen, sb, DMZ_BLOCK_SIZE);
 	sb->crc = __cpu_to_le32(crc);
 
@@ -67,8 +83,7 @@ int dmz_write_super(struct dmz_dev *dev,
 	if (ret < 0)
 		fprintf(stderr,
 			"%s: Write super block at block %llu failed\n",
-			bdev->name,
-			sb_block);
+			bdev->name, bdev_sb_block);
 
 	free(buf);
 
@@ -174,7 +189,6 @@ static int dmz_write_meta(struct dmz_dev *dev,
 		return -1;
 
 	/* Write super block */
-	printf("  Writing super block\n");
 	if (dmz_write_super(dev, 1, offset) < 0)
 		return -1;
 
@@ -186,14 +200,56 @@ static int dmz_write_meta(struct dmz_dev *dev,
  */
 int dmz_format(struct dmz_dev *dev)
 {
+	if (dev->sb_version > DMZ_META_VER) {
+		dev->sb_version = DMZ_META_VER;
+		fprintf(stderr, "Falling back to metadata version %d\n",
+			dev->sb_version);
+	} else if (!dev->sb_version) {
+		dev->sb_version = DMZ_META_VER;
+		fprintf(stderr, "Defaulting to metadata version %d\n",
+			dev->sb_version);
+	}
+	if (dev->sb_version > 1 && !strlen(dev->label))
+		sprintf(dev->label, "dmz-%s", dev->bdev[0].name);
 
 	/* calculate location of metadata blocks */
 	if (dmz_locate_metadata(dev) < 0)
 		return -1;
 
+	if (dev->sb_version > 1) {
+		if (uuid_is_null(dev->uuid))
+			uuid_generate_random(dev->uuid);
+		if (uuid_is_null(dev->bdev[0].uuid))
+			uuid_generate_random(dev->bdev[0].uuid);
+		if (dev->bdev[1].name && uuid_is_null(dev->bdev[1].uuid))
+			uuid_generate_random(dev->bdev[1].uuid);
+	}
 	if (dev->flags & DMZ_VERBOSE) {
 		unsigned int nr_seq_data_zones;
 
+		printf("Format metadata %d:\n", dev->sb_version);
+		if (dev->sb_version > 1) {
+			struct dmz_block_dev *bdev = &dev->bdev[0];
+			char dev_uuid[UUID_STR_LEN];
+			char bdev_uuid[UUID_STR_LEN];
+
+			uuid_unparse(dev->uuid, dev_uuid);
+			uuid_unparse(bdev->uuid, bdev_uuid);
+			printf("  DM-Zoned UUID %s\n", dev_uuid);
+			printf("  DM-Zoned Label %s\n", dev->label);
+			printf("  Device %s UUID %s\n",
+			       bdev->name, bdev_uuid);
+			if (dev->bdev[1].name) {
+				printf("  Device %s block offset %llu\n",
+				       bdev->name, bdev->block_offset);
+				bdev = &dev->bdev[1];
+				uuid_unparse(bdev->uuid, bdev_uuid);
+				printf("  Device %s UUID %s\n",
+				       bdev->name, bdev_uuid);
+				printf("  Device %s block offset %llu\n",
+				       bdev->name, bdev->block_offset);
+			}
+		}
 		printf("  %u useable zones\n",
 		       dev->nr_useable_zones);
 		printf("  Primary meta-data set: %u metadata blocks from block %llu (zone %u)\n",
@@ -245,9 +301,19 @@ int dmz_format(struct dmz_dev *dev)
 			   dev->zone_nr_blocks * dev->nr_meta_zones) < 0)
 		return -1;
 
+	if (dev->sb_version > 1 && dev->bdev[1].name) {
+		printf("Writing tertiary metadata\n");
+		if (dmz_write_super(dev, 0, dev->bdev[0].block_offset) < 0)
+			return -1;
+	}
+
 	/* Sync */
 	if (dmz_sync_dev(&dev->bdev[0]) < 0)
 		return -1;
+	if (dev->bdev[1].name) {
+		if (dmz_sync_dev(&dev->bdev[1]) < 0)
+			return -1;
+	}
 
 	printf("Done.\n");
 

--- a/src/dmz_format.c
+++ b/src/dmz_format.c
@@ -225,7 +225,7 @@ int dmz_format(struct dmz_dev *dev)
 			uuid_generate_random(dev->bdev[1].uuid);
 	}
 	if (dev->flags & DMZ_VERBOSE) {
-		unsigned int nr_seq_data_zones;
+		unsigned int nr_data_zones;
 
 		printf("Format metadata %d:\n", dev->sb_version);
 		if (dev->sb_version > 1) {
@@ -267,18 +267,18 @@ int dmz_format(struct dmz_dev *dev)
 		       dev->nr_meta_zones,
 		       dev->total_nr_meta_zones);
 
-		dev->nr_rnd_zones -= dev->total_nr_meta_zones;
-		nr_seq_data_zones = dev->nr_useable_zones
-			- (dev->total_nr_meta_zones + dev->nr_rnd_zones +
+		dev->nr_cache_zones -= dev->total_nr_meta_zones;
+		nr_data_zones = dev->nr_useable_zones
+			- (dev->total_nr_meta_zones + dev->nr_cache_zones +
 			dev->nr_reserved_seq);
 		printf("  %u data chunks capacity\n",
 		       dev->nr_chunks);
-		printf("    %u random zone%s\n",
-		       dev->nr_rnd_zones,
-		       dev->nr_rnd_zones > 1 ? "s" : "");
-		printf("    %u sequential zone%s\n",
-		       nr_seq_data_zones,
-		       nr_seq_data_zones > 1 ? "s" : "");
+		printf("    %u cache zone%s\n",
+		       dev->nr_cache_zones,
+		       dev->nr_cache_zones > 1 ? "s" : "");
+		printf("    %u data zone%s\n",
+		       nr_data_zones,
+		       nr_data_zones > 1 ? "s" : "");
 		printf("  %u sequential zone%s reserved for reclaim\n",
 		       dev->nr_reserved_seq,
 		       dev->nr_reserved_seq > 1 ? "s" : "");

--- a/src/dmz_lib.c
+++ b/src/dmz_lib.c
@@ -48,6 +48,7 @@ int dmz_reset_zone(struct dmz_dev *dev,
 		   struct blk_zone *zone)
 {
 	struct blk_zone_range range;
+	struct dmz_block_dev *bdev = &dev->bdev[0];
 
 	if (dmz_zone_conv(zone) ||
 	    dmz_zone_empty(zone))
@@ -56,10 +57,10 @@ int dmz_reset_zone(struct dmz_dev *dev,
 	/* Non empty sequential zone: reset */
 	range.sector = dmz_zone_sector(zone);
 	range.nr_sectors = dmz_zone_length(zone);
-	if (ioctl(dev->fd, BLKRESETZONE, &range) < 0) {
+	if (ioctl(bdev->fd, BLKRESETZONE, &range) < 0) {
 		fprintf(stderr,
 			"%s: Reset zone %u failed %d (%s)\n",
-			dev->name,
+			bdev->name,
 			dmz_zone_id(dev, zone),
 			errno, strerror(errno));
 		return -1;
@@ -108,21 +109,21 @@ int dmz_locate_metadata(struct dmz_dev *dev)
 
 		if (dmz_zone_cond(zone) == BLK_ZONE_COND_READONLY) {
 			printf("%s: Ignoring read-only zone %u\n",
-			       dev->name,
+			       dev->label,
 			       dmz_zone_id(dev, zone));
 			continue;
 		}
 
 		if (dmz_zone_cond(zone) == BLK_ZONE_COND_OFFLINE) {
 			printf("%s: Ignoring offline zone %u\n",
-			       dev->name,
+			       dev->label,
 			       dmz_zone_id(dev, zone));
 			continue;
 		}
 
 		if (dmz_zone_length(zone) != dev->zone_nr_sectors) {
 			printf("%s: Ignoring runt zone %u\n",
-			       dev->name,
+			       dev->label,
 			       dmz_zone_id(dev, zone));
 			continue;
 		}
@@ -149,7 +150,7 @@ int dmz_locate_metadata(struct dmz_dev *dev)
 	if (dev->nr_rnd_zones < 3) {
 		fprintf(stderr,
 			"%s: Not enough random zones found\n",
-			dev->name);
+			dev->label);
 		return -1;
 	}
 
@@ -162,7 +163,7 @@ int dmz_locate_metadata(struct dmz_dev *dev)
 	if (dev->nr_reserved_seq >= dev->nr_useable_zones) {
 		fprintf(stderr,
 			"%s: Not enough useable zones found\n",
-			dev->name);
+			dev->label);
 		return -1;
 	}
 
@@ -182,7 +183,7 @@ int dmz_locate_metadata(struct dmz_dev *dev)
 	if ((nr_bitmap_zones + dev->nr_reserved_seq) > dev->nr_useable_zones) {
 		fprintf(stderr,
 			"%s: Not enough zones\n",
-			dev->name);
+			dev->label);
 		return -1;
 	}
 
@@ -210,7 +211,7 @@ int dmz_locate_metadata(struct dmz_dev *dev)
 		fprintf(stderr,
 			"%s: Insufficient number of random zones "
 			"(need %u, have %u)\n",
-			dev->name,
+			dev->label,
 			dev->total_nr_meta_zones,
 			dev->nr_rnd_zones);
 		return -1;

--- a/src/dmz_lib.c
+++ b/src/dmz_lib.c
@@ -50,7 +50,8 @@ int dmz_reset_zone(struct dmz_dev *dev,
 	struct blk_zone_range range;
 	struct dmz_block_dev *bdev = &dev->bdev[1];
 
-	if (dmz_zone_conv(zone) ||
+	if (dmz_zone_unknown(zone) ||
+	    dmz_zone_conv(zone) ||
 	    dmz_zone_empty(zone))
 		return 0;
 
@@ -101,14 +102,14 @@ int dmz_locate_metadata(struct dmz_dev *dev)
 	dev->nr_useable_zones = 0;
 	dev->max_nr_meta_zones = 0;
 	dev->last_meta_zone = 0;
-	dev->nr_rnd_zones = 0;
+	dev->nr_cache_zones = 0;
 
 	/* Count useable zones */
 	for (i = 0; i < dev->nr_zones; i++) {
 
 		zone = &dev->zones[i];
 
-		if (dmz_zone_rnd(zone)) {
+		if (dmz_zone_is_cache(dev, zone)) {
 			if (dev->sb_zone == NULL) {
 				dev->sb_zone = zone;
 				dev->last_meta_zone = i;
@@ -117,7 +118,7 @@ int dmz_locate_metadata(struct dmz_dev *dev)
 				dev->last_meta_zone = i;
 				dev->max_nr_meta_zones++;
 			}
-			dev->nr_rnd_zones++;
+			dev->nr_cache_zones++;
 		} else {
 			if (dmz_zone_cond(zone) == BLK_ZONE_COND_READONLY) {
 				printf("  Ignoring read-only zone %u\n",
@@ -135,10 +136,10 @@ int dmz_locate_metadata(struct dmz_dev *dev)
 	}
 
 	/*
-	 * Randomly writeable zones are mandatory: at least 3
+	 * Cache zones are mandatory: at least 3
 	 * (two for metadata and one for bufferring random writes).
 	 */
-	if (dev->nr_rnd_zones < 3) {
+	if (dev->nr_cache_zones < 3) {
 		fprintf(stderr,
 			"%s: Not enough random zones found\n",
 			dev->label);
@@ -149,8 +150,8 @@ int dmz_locate_metadata(struct dmz_dev *dev)
 	 * It does not make sense to have more reserved
 	 * sequential zones than random zones.
 	 */
-	if (dev->nr_reserved_seq > dev->nr_rnd_zones)
-		dev->nr_reserved_seq = dev->nr_rnd_zones - 1;
+	if (dev->nr_reserved_seq > dev->nr_cache_zones)
+		dev->nr_reserved_seq = dev->nr_cache_zones - 1;
 	if (dev->nr_reserved_seq >= dev->nr_useable_zones) {
 		fprintf(stderr,
 			"%s: Not enough useable zones found\n",
@@ -198,13 +199,13 @@ int dmz_locate_metadata(struct dmz_dev *dev)
 			 / dev->zone_nr_blocks);
 	dev->total_nr_meta_zones = nr_meta_zones << 1;
 
-	if (dev->total_nr_meta_zones > dev->nr_rnd_zones) {
+	if (dev->total_nr_meta_zones > dev->nr_cache_zones) {
 		fprintf(stderr,
-			"%s: Insufficient number of random zones "
+			"%s: Insufficient number of cache zones "
 			"(need %u, have %u)\n",
 			dev->label,
 			dev->total_nr_meta_zones,
-			dev->nr_rnd_zones);
+			dev->nr_cache_zones);
 		return -1;
 	}
 

--- a/src/dmz_lib.c
+++ b/src/dmz_lib.c
@@ -48,7 +48,7 @@ int dmz_reset_zone(struct dmz_dev *dev,
 		   struct blk_zone *zone)
 {
 	struct blk_zone_range range;
-	struct dmz_block_dev *bdev = &dev->bdev[0];
+	struct dmz_block_dev *bdev = &dev->bdev[1];
 
 	if (dmz_zone_conv(zone) ||
 	    dmz_zone_empty(zone))
@@ -56,7 +56,7 @@ int dmz_reset_zone(struct dmz_dev *dev,
 
 	/* Non empty sequential zone: reset */
 	range.sector = dmz_zone_sector(zone) -
-		dmz_blk2sect(dev->bdev[0].block_offset);
+		dmz_blk2sect(dev->bdev[1].block_offset);
 	range.nr_sectors = dmz_zone_length(zone);
 	if (ioctl(bdev->fd, BLKRESETZONE, &range) < 0) {
 		fprintf(stderr,

--- a/src/dmzadm.c
+++ b/src/dmzadm.c
@@ -39,7 +39,7 @@ static void dmzadm_usage(void)
 
 	printf("Format operation options\n"
 	       "  --force	: Force overwrite of existing content\n"
-	       "  --seq <num>	: Number of sequential zones reserved\n"
+	       "  --seq=<num>	: Number of sequential zones reserved\n"
 	       "                  for reclaim. The minimum is 1 and the\n"
 	       "                  default is %d\n",
 	       DMZ_NR_RESERVED_SEQ);

--- a/src/dmzadm.c
+++ b/src/dmzadm.c
@@ -140,6 +140,27 @@ int main(int argc, char **argv)
 				return 1;
 			}
 
+		} else if (strncmp(argv[i], "--label=", 8) == 0) {
+			const char *label = argv[i] + 8;
+			unsigned int label_size = strlen(label);
+
+			if (op != DMZ_OP_FORMAT) {
+				fprintf(stderr,
+					"--label option is valid only with the "
+					"format operation\n");
+				return 1;
+			}
+			if (label[0] == '\'' || label[0] == '\"') {
+				label++;
+				label_size -= 2;
+			}
+			if (label_size > 31) {
+				fprintf(stderr,
+					"Label too long (max 16 characters)\n");
+				return 1;
+			}
+			memcpy(dev.label, label, label_size);
+
 		} else if (strcmp(argv[i], "--force") == 0) {
 
 			if (op != DMZ_OP_FORMAT) {

--- a/src/dmzadm.c
+++ b/src/dmzadm.c
@@ -48,6 +48,16 @@ static void dmzadm_usage(void)
 	       DMZ_NR_RESERVED_SEQ);
 }
 
+void print_dev_info(struct dmz_block_dev *bdev)
+{
+	printf("%s: %llu 512-byte sectors (%llu GiB)\n",
+	       bdev->path, bdev->capacity,
+	       (bdev->capacity << 9) / (1024ULL * 1024ULL * 1024ULL));
+	printf("  Host-%s device\n",
+	       (bdev->type == DMZ_TYPE_ZONED_HM) ? "managed" : "aware");
+
+}
+
 /*
  * Main function.
  */
@@ -55,12 +65,12 @@ int main(int argc, char **argv)
 {
 	unsigned int nr_zones;
 	struct dmz_dev dev;
-	int i, ret, log_level = 0;
+	int i, ret, log_level = 0, optnum;
 	enum dmz_op op;
 
 	/* Initialize */
 	memset(&dev, 0, sizeof(dev));
-	dev.fd = -1;
+	dev.bdev[0].fd = -1;
 	dev.nr_reserved_seq = DMZ_NR_RESERVED_SEQ;
 	dev.sb_version = DMZ_META_VER;
 
@@ -98,10 +108,11 @@ int main(int argc, char **argv)
 	}
 
 	/* Get device path */
-	dev.path = argv[2];
+	dev.bdev[0].path = argv[2];
+	optnum = 3;
 
 	/* Parse arguments */
-	for (i = 3; i < argc; i++) {
+	for (i = optnum; i < argc; i++) {
 
 		if (strcmp(argv[i], "--verbose") == 0) {
 
@@ -160,35 +171,31 @@ int main(int argc, char **argv)
 	if (ret <= 0)
 		return 1;
 
-	if (ret < DMZ_META_VER) {
-		printf("Falling back to metadata version %d\n", ret);
-		dev.sb_version = ret;
-	} else
-		printf("Using metadata version %d\n", dev.sb_version);
-
 	if (op == DMZ_OP_STOP) {
 		char holder[PATH_MAX];
 
-		if (dmz_get_dev_holder(&dev, holder) < 0)
+		if (dmz_get_dev_holder(&dev.bdev[0], holder) < 0)
 			return 1;
 		if (!strlen(holder)) {
 			fprintf(stderr, "%s: no dm-zoned device found\n",
-				dev.name);
+				dev.bdev[0].name);
 			return 1;
 		}
 		return dmz_stop(&dev, holder);
 	}
 
 	/* Open the device */
-	if (dmz_open_dev(&dev, op) < 0)
+	if (dmz_open_dev(&dev.bdev[0], op, dev.flags) < 0)
 		return 1;
 
-	printf("%s: %llu 512-byte sectors (%llu GiB)\n",
-	       dev.path,
-	       dev.capacity,
-	       (dev.capacity << 9) / (1024ULL * 1024ULL * 1024ULL));
-	printf("  Host-%s device\n",
-	       (dev.flags & DMZ_ZONED_HM) ? "managed" : "aware");
+	print_dev_info(&dev.bdev[0]);
+	dev.capacity = dev.bdev[0].capacity;
+	dev.zone_nr_sectors = dev.bdev[0].zone_nr_sectors;
+	dev.zone_nr_blocks = dev.bdev[0].zone_nr_blocks;
+
+	if (dmz_get_dev_zones(&dev) < 0)
+		return 1;
+
 	nr_zones = dev.capacity / dev.zone_nr_sectors;
 	printf("  %u zones of %zu 512-byte sectors (%zu MiB)\n",
 	       nr_zones,
@@ -230,7 +237,9 @@ int main(int argc, char **argv)
 
 	}
 
-	dmz_close_dev(&dev);
+	free(dev.zones);
+	dev.zones = NULL;
+	dmz_close_dev(&dev.bdev[0]);
 
 	return ret;
 }

--- a/src/dmzadm.c
+++ b/src/dmzadm.c
@@ -32,7 +32,8 @@ static void dmzadm_usage(void)
 	       "  --format	: Format a block device metadata\n"
 	       "  --check	: Check a block device metadata\n"
 	       "  --repair	: Repair a block device metadata\n"
-	       "  --start	: Start the device-mapper target\n");
+	       "  --start	: Start the device-mapper target\n"
+	       "  --stop	: Stop the device-mapper target\n");
 
 	printf("General options\n"
 	       "  --verbose	: Verbose output\n"
@@ -82,6 +83,8 @@ int main(int argc, char **argv)
 		op = DMZ_OP_REPAIR;
 	} else if (strcmp(argv[1], "--start") == 0) {
 		op = DMZ_OP_START;
+	} else if (strcmp(argv[1], "--stop") == 0) {
+		op = DMZ_OP_STOP;
 	} else {
 		fprintf(stderr,
 			"Unknown operation \"%s\"\n",
@@ -162,6 +165,19 @@ int main(int argc, char **argv)
 		dev.sb_version = ret;
 	} else
 		printf("Using metadata version %d\n", dev.sb_version);
+
+	if (op == DMZ_OP_STOP) {
+		char holder[PATH_MAX];
+
+		if (dmz_get_dev_holder(&dev, holder) < 0)
+			return 1;
+		if (!strlen(holder)) {
+			fprintf(stderr, "%s: no dm-zoned device found\n",
+				dev.name);
+			return 1;
+		}
+		return dmz_stop(&dev, holder);
+	}
 
 	/* Open the device */
 	if (dmz_open_dev(&dev, op) < 0)

--- a/src/dmzadm.c
+++ b/src/dmzadm.c
@@ -31,7 +31,8 @@ static void dmzadm_usage(void)
 	       "  --help | -h	: General help message\n"
 	       "  --format	: Format a block device metadata\n"
 	       "  --check	: Check a block device metadata\n"
-	       "  --repair	: Repair a block device metadata\n");
+	       "  --repair	: Repair a block device metadata\n"
+	       "  --start	: Start the device-mapper target\n");
 
 	printf("General options\n"
 	       "  --verbose	: Verbose output\n"
@@ -39,6 +40,7 @@ static void dmzadm_usage(void)
 
 	printf("Format operation options\n"
 	       "  --force	: Force overwrite of existing content\n"
+	       "  --label=<str> : Set the name to <str>\n"
 	       "  --seq=<num>	: Number of sequential zones reserved\n"
 	       "                  for reclaim. The minimum is 1 and the\n"
 	       "                  default is %d\n",
@@ -78,6 +80,8 @@ int main(int argc, char **argv)
 		op = DMZ_OP_CHECK;
 	} else if (strcmp(argv[1], "--repair") == 0) {
 		op = DMZ_OP_REPAIR;
+	} else if (strcmp(argv[1], "--start") == 0) {
+		op = DMZ_OP_START;
 	} else {
 		fprintf(stderr,
 			"Unknown operation \"%s\"\n",
@@ -196,6 +200,10 @@ int main(int argc, char **argv)
 
 	case DMZ_OP_REPAIR:
 		ret = dmz_repair(&dev);
+		break;
+
+	case DMZ_OP_START:
+		ret = dmz_start(&dev);
 		break;
 
 	default:

--- a/src/dmzadm.c
+++ b/src/dmzadm.c
@@ -222,38 +222,50 @@ int main(int argc, char **argv)
 	/* Open the device */
 	if (dmz_open_dev(&dev.bdev[0], op, dev.flags) < 0)
 		return 1;
-	if (!dmz_bdev_is_zoned(&dev.bdev[0])) {
-		fprintf(stderr,
-			"%s: Not a zoned block device\n",
-			dev.bdev[0].name);
-		dmz_close_dev(&dev.bdev[0]);
-		return 1;
+	if (dev.bdev[1].path) {
+		if (dmz_bdev_is_zoned(&dev.bdev[0])) {
+			fprintf(stderr,
+				"%s: Not a regular block device\n",
+				dev.bdev[0].name);
+			dmz_close_dev(&dev.bdev[0]);
+			return 1;
+		}
+	} else {
+		if (!dmz_bdev_is_zoned(&dev.bdev[0])) {
+			fprintf(stderr,
+				"%s: Not a zoned block device\n",
+				dev.bdev[0].name);
+			dmz_close_dev(&dev.bdev[0]);
+			return 1;
+		}
+		dev.zone_nr_sectors = dev.bdev[0].zone_nr_sectors;
+		dev.zone_nr_blocks = dev.bdev[0].zone_nr_blocks;
 	}
 	print_dev_info(&dev.bdev[0]);
 	dev.capacity = dev.bdev[0].capacity;
-	dev.zone_nr_sectors = dev.bdev[0].zone_nr_sectors;
-	dev.zone_nr_blocks = dev.bdev[0].zone_nr_blocks;
 
 	if (dev.bdev[1].path) {
 		__u64 nr_zones;
 
 		if (dmz_open_dev(&dev.bdev[1], op, dev.flags) < 0)
 			return 1;
-		if (dmz_bdev_is_zoned(&dev.bdev[1])) {
+		if (!dmz_bdev_is_zoned(&dev.bdev[1])) {
 			fprintf(stderr,
-				"%s: Not a regular block device\n",
+				"%s: Not a zoned block device\n",
 				dev.bdev[1].name);
 			ret = 1;
 			goto out_close;
 		}
 		print_dev_info(&dev.bdev[1]);
 		dev.capacity += dev.bdev[1].capacity;
-		dev.bdev[1].zone_nr_sectors = dev.zone_nr_sectors;
-		dev.bdev[1].zone_nr_blocks = dev.zone_nr_blocks;
-		nr_zones = dev.bdev[1].capacity / dev.zone_nr_sectors;
-		if (dev.bdev[1].capacity % dev.zone_nr_sectors)
+		dev.zone_nr_sectors = dev.bdev[1].zone_nr_sectors;
+		dev.zone_nr_blocks = dev.bdev[1].zone_nr_blocks;
+		dev.bdev[0].zone_nr_sectors = dev.zone_nr_sectors;
+		dev.bdev[0].zone_nr_blocks = dev.zone_nr_blocks;
+		nr_zones = dev.bdev[0].capacity / dev.zone_nr_sectors;
+		if (dev.bdev[0].capacity % dev.zone_nr_sectors)
 			nr_zones++;
-		dev.bdev[0].block_offset = nr_zones * dev.zone_nr_blocks;
+		dev.bdev[1].block_offset = nr_zones * dev.zone_nr_blocks;
 	}
 
 	if (dmz_get_dev_zones(&dev) < 0)


### PR DESCRIPTION
Hi Damien,

here's the patchset accompanying the latest change to dm-zoned for separating 'cache' and 'data' zones. It also includes a fix for wrting the tertiary metadata correctly .