### PR TITLE
configure: use pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,18 +30,8 @@ AC_CHECK_HEADER(mntent.h, [],
 		[AC_MSG_ERROR([Couldn't find mntent.h])])
 AC_CHECK_HEADER(linux/fs.h, [],
 		[AC_MSG_ERROR([Couldn't find linux/fs.h])])
-AC_CHECK_HEADER(blkid/blkid.h, [],
-		[AC_MSG_ERROR([Couldn't find blkid/blkid.h])])
 AC_CHECK_HEADER(linux/blkzoned.h, [],
 		[AC_MSG_ERROR([Couldn't find linux/blkzoned.h])])
-AC_CHECK_HEADER(uuid/uuid.h, [],
-		[AC_MSG_ERROR([Couldn't find uuid/uuid.h])])
-AC_CHECK_HEADER(libdevmapper.h, [],
-		[AC_MSG_ERROR([Couldn't find libdevmapper.h])])
-AC_CHECK_HEADER(libkmod.h, [],
-		[AC_MSG_ERROR([Couldn't find libkmod.h])])
-AC_CHECK_HEADER(libudev.h, [],
-		[AC_MSG_ERROR([Couldn't find libudev.h (install systemd-devel)])])
 
 AC_CHECK_MEMBER([struct blk_zone.capacity],
 		[AC_DEFINE(HAVE_BLK_ZONE_REP_V2, [1],
@@ -49,20 +39,11 @@ AC_CHECK_MEMBER([struct blk_zone.capacity],
 		[], [[#include <linux/blkzoned.h>]])
 
 # Checks for libraries.
-AC_SEARCH_LIBS([blkid_do_fullprobe], [blkid], [],
-	       [AC_MSG_ERROR([Couldn't find libblkid])])
-
-AC_SEARCH_LIBS([uuid_generate_random], [uuid], [],
-		[AC_MSG_ERROR([Couldn't find libuuid])])
-
-AC_SEARCH_LIBS([dm_task_run], [devmapper], [],
-		[AC_MSG_ERROR([Couldn't find libdevmapper])])
-
-AC_SEARCH_LIBS([kmod_module_ref], [kmod], [],
-		[AC_MSG_ERROR([Couldn't find libkmod])])
-
-AC_SEARCH_LIBS([udev_new], [udev], [],
-		[AC_MSG_ERROR([Couldn't find libudev])])
+PKG_CHECK_MODULES([blkid], [blkid])
+PKG_CHECK_MODULES([kmod], [libkmod])
+PKG_CHECK_MODULES([libudev], [libudev])
+PKG_CHECK_MODULES([uuid], [uuid])
+PKG_CHECK_MODULES([devmapper], [devmapper])
 
 # Checks for rpm package builds
 AC_PATH_PROG([RPMBUILD], [rpmbuild], [notfound])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,8 @@
 #
 # Copyright (C) 2020 Western Digital Corporation or its affiliates.
 
-AM_CPPFLAGS = -O2 -Wall -Wextra -Wno-unused-parameter
+AM_CPPFLAGS = -O2 -Wall -Wextra -Wno-unused-parameter \
+	      $(kmod_CFLAGS) $(blkid_CFLAGS) $(uuid_CFLAGS)
 
 sbin_PROGRAMS = dmzadm
 
@@ -16,4 +17,4 @@ HFILES = dmz.h
 
 dmzadm_SOURCES = ${CFILES} ${HFILES}
 dmzadm_LDADD =
-dmzadm_LDFLAGS = -lblkid -luuid -ldevmapper -lkmod -ludev
+dmzadm_LDFLAGS = $(blkid_LIBS) $(uuid_LIBS) $(devmapper_LIBS) $(kmod_LIBS) $(libudev_LIBS)


### PR DESCRIPTION
There was a build problem with the update to version 2.2.0 on openSUSE
because on openSUSE the include path of libkmod.h is different than on
i.e. Fedora.

Use pkg-config to obtain the CFLAGS and LIBS for all external libraries so
we're not running into this kind of problem again in the future and/or
don't need a openSUSE specific external patch to fix the build.

Signed-off-by: Johannes Thumshirn <johannes.thumshirn@wdc.com>